### PR TITLE
fix: move some devdependencies to normal dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,11 @@
 			"name": "@technologiestiftung/eslint-config",
 			"version": "0.3.0",
 			"license": "MIT",
+			"dependencies": {
+				"@eslint/js": "9.12.0",
+				"typescript-eslint": "8.9.0"
+			},
 			"devDependencies": {
-				"@eslint/js": "9.4.0",
 				"@technologiestiftung/semantic-release-config": "1.2.4",
 				"@types/eslint": "9.6.1",
 				"@types/eslint__js": "8.42.3",
@@ -17,124 +20,44 @@
 				"eslint": "9.4.0",
 				"prettier": "3.3.3",
 				"semantic-release": "24.1.2",
-				"typescript": "5.4.5",
-				"typescript-eslint": "8.0.0-alpha.10"
+				"typescript": "5.4.5"
 			},
 			"peerDependencies": {
 				"eslint": ">= 9.0.0"
 			}
 		},
-		"node_modules/@aashutoshrathi/word-wrap": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-			"integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
-			"integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.7.tgz",
+			"integrity": "sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==",
 			"dev": true,
 			"dependencies": {
-				"@babel/highlight": "^7.23.4",
-				"chalk": "^2.4.2"
+				"@babel/highlight": "^7.25.7",
+				"picocolors": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/code-frame/node_modules/ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
-		},
-		"node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/@babel/code-frame/node_modules/supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
+			"integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
-			"integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.7.tgz",
+			"integrity": "sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.22.20",
+				"@babel/helper-validator-identifier": "^7.25.7",
 				"chalk": "^2.4.2",
-				"js-tokens": "^4.0.0"
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -165,21 +88,6 @@
 			"engines": {
 				"node": ">=4"
 			}
-		},
-		"node_modules/@babel/highlight/node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/@babel/highlight/node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
 		},
 		"node_modules/@babel/highlight/node_modules/escape-string-regexp": {
 			"version": "1.0.5",
@@ -225,7 +133,6 @@
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
 			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
-			"dev": true,
 			"dependencies": {
 				"eslint-visitor-keys": "^3.3.0"
 			},
@@ -236,11 +143,21 @@
 				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
 			}
 		},
+		"node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.10.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
-			"integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
-			"dev": true,
+			"version": "4.11.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
+			"integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
@@ -249,7 +166,6 @@
 			"version": "0.15.1",
 			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.15.1.tgz",
 			"integrity": "sha512-K4gzNq+yymn/EVsXYmf+SBcBro8MTf+aXJZUphM96CdzUEr+ClGDvAbpmaEK+cGVigVXIgs9gNmvHAlrzzY5JQ==",
-			"dev": true,
 			"dependencies": {
 				"@eslint/object-schema": "^2.1.3",
 				"debug": "^4.3.1",
@@ -263,7 +179,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
 			"integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
-			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -283,19 +198,17 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.4.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.4.0.tgz",
-			"integrity": "sha512-fdI7VJjP3Rvc70lC4xkFXHB0fiPeojiL1PxVG6t1ZvXQrarj893PweuBTujxDUFk0Fxj4R7PIIAZ/aiiyZPZcg==",
-			"dev": true,
+			"version": "9.12.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.12.0.tgz",
+			"integrity": "sha512-eohesHH8WFRUprDNyEREgqP6beG6htMeUYeCpkEgBCieCMme5r9zFWjzAJp//9S+Kub4rqE+jXe9Cp1a7IYIIA==",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@eslint/object-schema": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.3.tgz",
-			"integrity": "sha512-HAbhAYKfsAC2EkTqve00ibWIZlaU74Z1EHwAjYr4PXF0YU2VEA1zSIKSSpKszRLRWwHzzRZXvK632u+uXzvsvw==",
-			"dev": true,
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
+			"integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
@@ -304,7 +217,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
 			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-			"dev": true,
 			"engines": {
 				"node": ">=12.22"
 			},
@@ -314,10 +226,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/retry": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.0.tgz",
-			"integrity": "sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==",
-			"dev": true,
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+			"integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
 			"engines": {
 				"node": ">=18.18"
 			},
@@ -346,11 +257,35 @@
 				"node-pre-gyp": "bin/node-pre-gyp"
 			}
 		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"dev": true,
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/@mapbox/node-pre-gyp/node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
 			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-			"dev": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "2.0.5",
 				"run-parallel": "^1.1.9"
@@ -363,7 +298,6 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
 			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-			"dev": true,
 			"engines": {
 				"node": ">= 8"
 			}
@@ -372,7 +306,6 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
 			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-			"dev": true,
 			"dependencies": {
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
@@ -391,16 +324,16 @@
 			}
 		},
 		"node_modules/@octokit/core": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.1.0.tgz",
-			"integrity": "sha512-BDa2VAMLSh3otEiaMJ/3Y36GU4qf6GI+VivQ/P41NC6GHcdxpKlqV0ikSZ5gdQsmS3ojXeRx5vasgNTinF0Q4g==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
+			"integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
 			"dev": true,
 			"dependencies": {
 				"@octokit/auth-token": "^4.0.0",
-				"@octokit/graphql": "^7.0.0",
-				"@octokit/request": "^8.0.2",
-				"@octokit/request-error": "^5.0.0",
-				"@octokit/types": "^12.0.0",
+				"@octokit/graphql": "^7.1.0",
+				"@octokit/request": "^8.3.1",
+				"@octokit/request-error": "^5.1.0",
+				"@octokit/types": "^13.0.0",
 				"before-after-hook": "^2.2.0",
 				"universal-user-agent": "^6.0.0"
 			},
@@ -409,12 +342,12 @@
 			}
 		},
 		"node_modules/@octokit/endpoint": {
-			"version": "9.0.4",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.4.tgz",
-			"integrity": "sha512-DWPLtr1Kz3tv8L0UvXTDP1fNwM0S+z6EJpRcvH66orY6Eld4XBMCSYsaWp4xIm61jTWxK68BrR7ibO+vSDnZqw==",
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.5.tgz",
+			"integrity": "sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==",
 			"dev": true,
 			"dependencies": {
-				"@octokit/types": "^12.0.0",
+				"@octokit/types": "^13.1.0",
 				"universal-user-agent": "^6.0.0"
 			},
 			"engines": {
@@ -422,13 +355,13 @@
 			}
 		},
 		"node_modules/@octokit/graphql": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.2.tgz",
-			"integrity": "sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.0.tgz",
+			"integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
 			"dev": true,
 			"dependencies": {
-				"@octokit/request": "^8.0.1",
-				"@octokit/types": "^12.0.0",
+				"@octokit/request": "^8.3.0",
+				"@octokit/types": "^13.0.0",
 				"universal-user-agent": "^6.0.0"
 			},
 			"engines": {
@@ -436,9 +369,9 @@
 			}
 		},
 		"node_modules/@octokit/openapi-types": {
-			"version": "20.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-			"integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+			"version": "22.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
+			"integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
 			"dev": true
 		},
 		"node_modules/@octokit/plugin-paginate-rest": {
@@ -488,6 +421,21 @@
 				"@octokit/core": ">=5"
 			}
 		},
+		"node_modules/@octokit/plugin-retry/node_modules/@octokit/openapi-types": {
+			"version": "20.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+			"integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+			"dev": true
+		},
+		"node_modules/@octokit/plugin-retry/node_modules/@octokit/types": {
+			"version": "12.6.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+			"integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/openapi-types": "^20.0.0"
+			}
+		},
 		"node_modules/@octokit/plugin-throttling": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-7.0.0.tgz",
@@ -520,14 +468,14 @@
 			}
 		},
 		"node_modules/@octokit/request": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.2.0.tgz",
-			"integrity": "sha512-exPif6x5uwLqv1N1irkLG1zZNJkOtj8bZxuVHd71U5Ftuxf2wGNvAJyNBcPbPC+EBzwYEbBDdSFb8EPcjpYxPQ==",
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.0.tgz",
+			"integrity": "sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==",
 			"dev": true,
 			"dependencies": {
-				"@octokit/endpoint": "^9.0.0",
-				"@octokit/request-error": "^5.0.0",
-				"@octokit/types": "^12.0.0",
+				"@octokit/endpoint": "^9.0.1",
+				"@octokit/request-error": "^5.1.0",
+				"@octokit/types": "^13.1.0",
 				"universal-user-agent": "^6.0.0"
 			},
 			"engines": {
@@ -535,12 +483,12 @@
 			}
 		},
 		"node_modules/@octokit/request-error": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.1.tgz",
-			"integrity": "sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.0.tgz",
+			"integrity": "sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==",
 			"dev": true,
 			"dependencies": {
-				"@octokit/types": "^12.0.0",
+				"@octokit/types": "^13.1.0",
 				"deprecation": "^2.0.0",
 				"once": "^1.4.0"
 			},
@@ -549,12 +497,12 @@
 			}
 		},
 		"node_modules/@octokit/types": {
-			"version": "12.6.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-			"integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+			"version": "13.6.1",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.6.1.tgz",
+			"integrity": "sha512-PHZE9Z+kWXb23Ndik8MKPirBPziOc0D2/3KH1P+6jK5nGWe96kadZuE4jev2/Jq7FvIfTlT2Ltg8Fv2x1v0a5g==",
 			"dev": true,
 			"dependencies": {
-				"@octokit/openapi-types": "^20.0.0"
+				"@octokit/openapi-types": "^22.2.0"
 			}
 		},
 		"node_modules/@pnpm/config.env-replace": {
@@ -585,9 +533,9 @@
 			"dev": true
 		},
 		"node_modules/@pnpm/npm-conf": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.2.2.tgz",
-			"integrity": "sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.3.1.tgz",
+			"integrity": "sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==",
 			"dev": true,
 			"dependencies": {
 				"@pnpm/config.env-replace": "^1.1.0",
@@ -611,12 +559,23 @@
 				"node": ">= 8.0.0"
 			}
 		},
+		"node_modules/@rollup/pluginutils/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/@sec-ant/readable-stream": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
 			"integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
-			"dev": true,
-			"license": "MIT"
+			"dev": true
 		},
 		"node_modules/@semantic-release/changelog": {
 			"version": "6.0.3",
@@ -727,18 +686,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/@semantic-release/github/node_modules/agent-base": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-			"integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-			"dev": true,
-			"dependencies": {
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/@semantic-release/github/node_modules/aggregate-error": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
@@ -782,42 +729,10 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@semantic-release/github/node_modules/globby": {
-			"version": "13.2.2",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-			"integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
-			"dev": true,
-			"dependencies": {
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.3.0",
-				"ignore": "^5.2.4",
-				"merge2": "^1.4.1",
-				"slash": "^4.0.0"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@semantic-release/github/node_modules/https-proxy-agent": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-			"integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
-			"dev": true,
-			"dependencies": {
-				"agent-base": "^7.0.2",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/@semantic-release/github/node_modules/slash": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-			"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+		"node_modules/@semantic-release/github/node_modules/indent-string": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
@@ -947,6 +862,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=16.17.0"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/indent-string": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@semantic-release/npm/node_modules/is-stream": {
@@ -1108,7 +1035,6 @@
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
 			"integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
@@ -1124,9 +1050,9 @@
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
 			"dev": true
 		},
 		"node_modules/@types/json-schema": {
@@ -1148,21 +1074,18 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.0.0-alpha.10",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.0.0-alpha.10.tgz",
-			"integrity": "sha512-jsNKqn41nIS8jz5Li5xsueGEBBmRYLaflUKlclEkj8cWrO1tMK1/7xITeiVz7ZlNFZF2nop2NlXrbLtRpLEzhg==",
-			"dev": true,
+			"version": "8.9.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.9.0.tgz",
+			"integrity": "sha512-Y1n621OCy4m7/vTXNlCbMVp87zSd7NH0L9cXD8aIpOaNlzeWxIK4+Q19A68gSmTNRZn92UjocVUWDthGxtqHFg==",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.0.0-alpha.10",
-				"@typescript-eslint/type-utils": "8.0.0-alpha.10",
-				"@typescript-eslint/utils": "8.0.0-alpha.10",
-				"@typescript-eslint/visitor-keys": "8.0.0-alpha.10",
-				"debug": "^4.3.4",
+				"@typescript-eslint/scope-manager": "8.9.0",
+				"@typescript-eslint/type-utils": "8.9.0",
+				"@typescript-eslint/utils": "8.9.0",
+				"@typescript-eslint/visitor-keys": "8.9.0",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.3.1",
 				"natural-compare": "^1.4.0",
-				"semver": "^7.6.0",
 				"ts-api-utils": "^1.3.0"
 			},
 			"engines": {
@@ -1173,7 +1096,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^7.0.0",
+				"@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
 				"eslint": "^8.57.0 || ^9.0.0"
 			},
 			"peerDependenciesMeta": {
@@ -1183,78 +1106,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "7.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.12.0.tgz",
-			"integrity": "sha512-dm/J2UDY3oV3TKius2OUZIFHsomQmpHtsV0FTh1WO8EKgHLQ1QCADUqscPgTpU+ih1e21FQSRjXckHn3txn6kQ==",
-			"dev": true,
-			"peer": true,
+			"version": "8.9.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.9.0.tgz",
+			"integrity": "sha512-U+BLn2rqTTHnc4FL3FJjxaXptTxmf9sNftJK62XLz4+GxG3hLHm/SUNaaXP5Y4uTiuYoL5YLy4JBCJe3+t8awQ==",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "7.12.0",
-				"@typescript-eslint/types": "7.12.0",
-				"@typescript-eslint/typescript-estree": "7.12.0",
-				"@typescript-eslint/visitor-keys": "7.12.0",
+				"@typescript-eslint/scope-manager": "8.9.0",
+				"@typescript-eslint/types": "8.9.0",
+				"@typescript-eslint/typescript-estree": "8.9.0",
+				"@typescript-eslint/visitor-keys": "8.9.0",
 				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^8.56.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-			"version": "7.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.12.0.tgz",
-			"integrity": "sha512-itF1pTnN6F3unPak+kutH9raIkL3lhH1YRPGgt7QQOh43DQKVJXmWkpb+vpc/TiDHs6RSd9CTbDsc/Y+Ygq7kg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@typescript-eslint/types": "7.12.0",
-				"@typescript-eslint/visitor-keys": "7.12.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "7.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.12.0.tgz",
-			"integrity": "sha512-uZk7DevrQLL3vSnfFl5bj4sL75qC9D6EdjemIdbtkuUmIheWpuiiylSY01JxJE7+zGrOWDZrp1WxOuDntvKrHQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@typescript-eslint/types": "7.12.0",
-				"eslint-visitor-keys": "^3.4.3"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.0.0-alpha.10",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.0.0-alpha.10.tgz",
-			"integrity": "sha512-SUU0yhqehjuWilWRJWfhcxf6eMKVrZ3bpV2w6NF6GmBHR3FJo6oWZYLVXP04s6//INxpC2ynvKSglo4LRzWVTw==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/types": "8.0.0-alpha.10",
-				"@typescript-eslint/visitor-keys": "8.0.0-alpha.10"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1262,13 +1122,24 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@typescript-eslint/scope-manager/node_modules/@typescript-eslint/types": {
-			"version": "8.0.0-alpha.10",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.0.0-alpha.10.tgz",
-			"integrity": "sha512-prbN+b/I4yH6H43WmyenMz8K5e34Hs73BQuWXR4wwij3Cg2xNGLPcpjr2cKWKlH4dZQPTz6R6oBeC+LfaoKi8g==",
-			"dev": true,
+		"node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.9.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.9.0.tgz",
+			"integrity": "sha512-bZu9bUud9ym1cabmOYH9S6TnbWRzpklVmwqICeOulTCZ9ue2/pczWzQvt/cGj2r2o1RdKoZbuEMalJJSYw3pHQ==",
+			"dependencies": {
+				"@typescript-eslint/types": "8.9.0",
+				"@typescript-eslint/visitor-keys": "8.9.0"
+			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
@@ -1278,13 +1149,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.0.0-alpha.10",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.0.0-alpha.10.tgz",
-			"integrity": "sha512-6aTcbnDZWKgKr3gquECJSFyvXWLSKtUHrk2ZXDP4DEzmzTDjrkY7tIQpqv4SczPQJ+3/aky3ArPhtnQYJbAMzg==",
-			"dev": true,
+			"version": "8.9.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.9.0.tgz",
+			"integrity": "sha512-JD+/pCqlKqAk5961vxCluK+clkppHY07IbV3vett97KOV+8C6l+CPEPwpUuiMwgbOz/qrN3Ke4zzjqbT+ls+1Q==",
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "8.0.0-alpha.10",
-				"@typescript-eslint/utils": "8.0.0-alpha.10",
+				"@typescript-eslint/typescript-estree": "8.9.0",
+				"@typescript-eslint/utils": "8.9.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.3.0"
 			},
@@ -1299,81 +1169,14 @@
 				"typescript": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
-			"version": "8.0.0-alpha.10",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.0.0-alpha.10.tgz",
-			"integrity": "sha512-prbN+b/I4yH6H43WmyenMz8K5e34Hs73BQuWXR4wwij3Cg2xNGLPcpjr2cKWKlH4dZQPTz6R6oBeC+LfaoKi8g==",
-			"dev": true,
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.0.0-alpha.10",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.0.0-alpha.10.tgz",
-			"integrity": "sha512-8wBUIhu6IRa440hv5/0ZEnb5JLp/UsfzIXYKRwICUOMTVj2ss1n+w3m1CtT5ghVWy5Z05qkscsbhlKFmZguU8w==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/types": "8.0.0-alpha.10",
-				"@typescript-eslint/visitor-keys": "8.0.0-alpha.10",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"minimatch": "^9.0.4",
-				"semver": "^7.6.0",
-				"ts-api-utils": "^1.3.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/type-utils/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/@typescript-eslint/type-utils/node_modules/minimatch": {
-			"version": "9.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-			"integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-			"dev": true,
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "7.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.12.0.tgz",
-			"integrity": "sha512-o+0Te6eWp2ppKY3mLCU+YA9pVJxhUJE15FV7kxuD9jgwIAa+w/ycGJBMrYDTpVGUM/tgpa9SeMOugSabWFq7bg==",
-			"dev": true,
-			"peer": true,
+			"version": "8.9.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.9.0.tgz",
+			"integrity": "sha512-SjgkvdYyt1FAPhU9c6FiYCXrldwYYlIQLkuc+LfAhCna6ggp96ACncdtlbn8FmnG72tUkXclrDExOpEYf1nfJQ==",
 			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1381,23 +1184,21 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "7.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.12.0.tgz",
-			"integrity": "sha512-5bwqLsWBULv1h6pn7cMW5dXX/Y2amRqLaKqsASVwbBHMZSnHqE/HN4vT4fE0aFsiwxYvr98kqOWh1a8ZKXalCQ==",
-			"dev": true,
-			"peer": true,
+			"version": "8.9.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.9.0.tgz",
+			"integrity": "sha512-9iJYTgKLDG6+iqegehc5+EqE6sqaee7kb8vWpmHZ86EqwDjmlqNNHeqDVqb9duh+BY6WCNHfIGvuVU3Tf9Db0g==",
 			"dependencies": {
-				"@typescript-eslint/types": "7.12.0",
-				"@typescript-eslint/visitor-keys": "7.12.0",
+				"@typescript-eslint/types": "8.9.0",
+				"@typescript-eslint/visitor-keys": "8.9.0",
 				"debug": "^4.3.4",
-				"globby": "^11.1.0",
+				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
 				"minimatch": "^9.0.4",
 				"semver": "^7.6.0",
 				"ts-api-utils": "^1.3.0"
 			},
 			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1409,40 +1210,18 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "7.12.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.12.0.tgz",
-			"integrity": "sha512-uZk7DevrQLL3vSnfFl5bj4sL75qC9D6EdjemIdbtkuUmIheWpuiiylSY01JxJE7+zGrOWDZrp1WxOuDntvKrHQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@typescript-eslint/types": "7.12.0",
-				"eslint-visitor-keys": "^3.4.3"
-			},
-			"engines": {
-				"node": "^18.18.0 || >=20.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
 			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-			"version": "9.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-			"integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-			"dev": true,
-			"peer": true,
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
@@ -1454,18 +1233,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.0.0-alpha.10",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.0.0-alpha.10.tgz",
-			"integrity": "sha512-WZyNf49CuvaW/whz/B8XjYwXE/wm/EQAXq+Vqgp6BrJb8SC3bMCwGuUxReNDN1o+dNdOC96ofVSvqa8NUQ65Jg==",
-			"dev": true,
+			"version": "8.9.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.9.0.tgz",
+			"integrity": "sha512-PKgMmaSo/Yg/F7kIZvrgrWa1+Vwn036CdNUvYFEkYbPwOH4i8xvkaRlu148W3vtheWK9ckKRIz7PBP5oUlkrvQ==",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
-				"@types/json-schema": "^7.0.15",
-				"@types/semver": "^7.5.8",
-				"@typescript-eslint/scope-manager": "8.0.0-alpha.10",
-				"@typescript-eslint/types": "8.0.0-alpha.10",
-				"@typescript-eslint/typescript-estree": "8.0.0-alpha.10",
-				"semver": "^7.6.0"
+				"@typescript-eslint/scope-manager": "8.9.0",
+				"@typescript-eslint/types": "8.9.0",
+				"@typescript-eslint/typescript-estree": "8.9.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1478,78 +1253,12 @@
 				"eslint": "^8.57.0 || ^9.0.0"
 			}
 		},
-		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-			"version": "8.0.0-alpha.10",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.0.0-alpha.10.tgz",
-			"integrity": "sha512-prbN+b/I4yH6H43WmyenMz8K5e34Hs73BQuWXR4wwij3Cg2xNGLPcpjr2cKWKlH4dZQPTz6R6oBeC+LfaoKi8g==",
-			"dev": true,
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.0.0-alpha.10",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.0.0-alpha.10.tgz",
-			"integrity": "sha512-8wBUIhu6IRa440hv5/0ZEnb5JLp/UsfzIXYKRwICUOMTVj2ss1n+w3m1CtT5ghVWy5Z05qkscsbhlKFmZguU8w==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/types": "8.0.0-alpha.10",
-				"@typescript-eslint/visitor-keys": "8.0.0-alpha.10",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"minimatch": "^9.0.4",
-				"semver": "^7.6.0",
-				"ts-api-utils": "^1.3.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@typescript-eslint/utils/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/@typescript-eslint/utils/node_modules/minimatch": {
-			"version": "9.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-			"integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-			"dev": true,
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.0.0-alpha.10",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.0.0-alpha.10.tgz",
-			"integrity": "sha512-UohTNnT7S29uQgXsGZY489nWmoBBSJucNdRvog62R1QX9pQQb2pKVV1kHepUxoY2vd+M4tb9SQwZQ3gPNgqQ6w==",
-			"dev": true,
+			"version": "8.9.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.9.0.tgz",
+			"integrity": "sha512-Ht4y38ubk4L5/U8xKUBfKNYGmvKvA1CANoxiTRMM+tOLk3lbF3DvzZCxJCRSE+2GdCMSh6zq9VZJc3asc1XuAA==",
 			"dependencies": {
-				"@typescript-eslint/types": "8.0.0-alpha.10",
+				"@typescript-eslint/types": "8.9.0",
 				"eslint-visitor-keys": "^3.4.3"
 			},
 			"engines": {
@@ -1560,23 +1269,21 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/visitor-keys/node_modules/@typescript-eslint/types": {
-			"version": "8.0.0-alpha.10",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.0.0-alpha.10.tgz",
-			"integrity": "sha512-prbN+b/I4yH6H43WmyenMz8K5e34Hs73BQuWXR4wwij3Cg2xNGLPcpjr2cKWKlH4dZQPTz6R6oBeC+LfaoKi8g==",
-			"dev": true,
+		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			},
 			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/@vercel/nft": {
-			"version": "0.26.4",
-			"resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.26.4.tgz",
-			"integrity": "sha512-j4jCOOXke2t8cHZCIxu1dzKLHLcFmYzC3yqAK6MfZznOL1QIJKd0xcFsXK3zcqzU7ScsE2zWkiMMNHGMHgp+FA==",
+			"version": "0.26.5",
+			"resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-0.26.5.tgz",
+			"integrity": "sha512-NHxohEqad6Ra/r4lGknO52uc/GrWILXAMs1BB4401GTqww0fw1bAqzpG1XHuDO+dprg4GvsD9ZLLSsdo78p9hQ==",
 			"dev": true,
 			"dependencies": {
 				"@mapbox/node-pre-gyp": "^1.0.5",
@@ -1599,15 +1306,6 @@
 				"node": ">=16"
 			}
 		},
-		"node_modules/@vercel/nft/node_modules/resolve-from": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -1615,10 +1313,9 @@
 			"dev": true
 		},
 		"node_modules/acorn": {
-			"version": "8.11.3",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-			"dev": true,
+			"version": "8.12.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+			"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1627,9 +1324,9 @@
 			}
 		},
 		"node_modules/acorn-import-attributes": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.2.tgz",
-			"integrity": "sha512-O+nfJwNolEA771IYJaiLWK1UAwjNsQmZbTRqqwBYxCgVQTmpFEMvBw6LOIQV0Me339L5UMVYFyRohGnGlQDdIQ==",
+			"version": "1.9.5",
+			"resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+			"integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
 			"dev": true,
 			"peerDependencies": {
 				"acorn": "^8"
@@ -1639,30 +1336,32 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
 		"node_modules/acorn-walk": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
-			"integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+			"version": "8.3.4",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+			"integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
 			"dev": true,
+			"dependencies": {
+				"acorn": "^8.11.0"
+			},
 			"engines": {
 				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/agent-base": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+			"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
 			"dev": true,
 			"dependencies": {
-				"debug": "4"
+				"debug": "^4.3.4"
 			},
 			"engines": {
-				"node": ">= 6.0.0"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/aggregate-error": {
@@ -1678,20 +1377,10 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/aggregate-error/node_modules/indent-string": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-			"dev": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -1704,51 +1393,39 @@
 			}
 		},
 		"node_modules/ansi-escapes": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.0.tgz",
-			"integrity": "sha512-kzRaCqXnpzWs+3z5ABPQiVke+iq0KXkHo8xiWV4RPTi5Yli0l97BEQuhXV1s7+aSU/fu1kUuxgS4MsQ0fRuygw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
+			"integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
 			"dev": true,
 			"dependencies": {
-				"type-fest": "^3.0.0"
+				"environment": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ansi-escapes/node_modules/type-fest": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-			"integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
-			"dev": true,
-			"engines": {
-				"node": ">=14.16"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+			"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
 			"dev": true,
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
 			}
 		},
 		"node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
 			"dev": true,
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -1770,6 +1447,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
 			"integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+			"deprecated": "This package is no longer supported.",
 			"dev": true,
 			"dependencies": {
 				"delegates": "^1.0.0",
@@ -1779,11 +1457,24 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/are-we-there-yet/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
 		},
 		"node_modules/argv-formatter": {
 			"version": "1.0.0",
@@ -1805,15 +1496,6 @@
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
 			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
 			"dev": true
-		},
-		"node_modules/array-union": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
 		},
 		"node_modules/arrgv": {
 			"version": "1.0.2",
@@ -1904,58 +1586,10 @@
 				}
 			}
 		},
-		"node_modules/ava/node_modules/ansi-regex": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/ava/node_modules/ansi-styles": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/ava/node_modules/callsites": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-4.1.0.tgz",
-			"integrity": "sha512-aBMbD1Xxay75ViYezwT40aQONfr+pSXTHwNKvIXhXD6+LY3F1dLIcceoC5OZKBVHbXcysz1hL9D2w0JJIMXpUw==",
-			"dev": true,
-			"engines": {
-				"node": ">=12.20"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ava/node_modules/chalk": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-			"dev": true,
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
 		"node_modules/ava/node_modules/globby": {
-			"version": "14.0.1",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-14.0.1.tgz",
-			"integrity": "sha512-jOMLD2Z7MAhyG8aJpNOpmziMOP4rPLcc95oQPKXBazW82z+CEgPFBQvEpRUa1KeIMUJo4Wsm+q6uzO/Q/4BksQ==",
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
+			"integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
 			"dev": true,
 			"dependencies": {
 				"@sindresorhus/merge-streams": "^2.1.0",
@@ -1972,11 +1606,17 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/ava/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
+		"node_modules/ava/node_modules/indent-string": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/ava/node_modules/path-type": {
 			"version": "5.0.0",
@@ -1988,18 +1628,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ava/node_modules/picomatch": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
-			"integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/ava/node_modules/slash": {
@@ -2014,26 +1642,10 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/ava/node_modules/strip-ansi": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
 		},
 		"node_modules/before-after-hook": {
 			"version": "2.2.3",
@@ -2066,7 +1678,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -2076,7 +1687,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
 			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"dev": true,
 			"dependencies": {
 				"fill-range": "^7.1.1"
 			},
@@ -2085,12 +1695,15 @@
 			}
 		},
 		"node_modules/callsites": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-4.2.0.tgz",
+			"integrity": "sha512-kfzR4zzQtAE9PC7CzZsjl3aBNbXWuXiSeOCdLcPpBfGW8YuCqQHcRPFDbr/BPVmd3EEPVpuFzLyuT/cUhPr4OQ==",
 			"dev": true,
 			"engines": {
-				"node": ">=6"
+				"node": ">=12.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/cbor": {
@@ -2106,16 +1719,12 @@
 			}
 		},
 		"node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
 			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
@@ -2196,6 +1805,46 @@
 				"npm": ">=5.0.0"
 			}
 		},
+		"node_modules/cli-highlight/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cli-highlight/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/cli-highlight/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
 		"node_modules/cli-highlight/node_modules/cliui": {
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -2206,6 +1855,24 @@
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^7.0.0"
 			}
+		},
+		"node_modules/cli-highlight/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/cli-highlight/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
 		},
 		"node_modules/cli-highlight/node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -2231,6 +1898,18 @@
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
 				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cli-highlight/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -2264,9 +1943,9 @@
 			}
 		},
 		"node_modules/cli-table3": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
-			"integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+			"integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
 			"dev": true,
 			"dependencies": {
 				"string-width": "^4.2.0"
@@ -2276,6 +1955,15 @@
 			},
 			"optionalDependencies": {
 				"@colors/colors": "1.5.0"
+			}
+		},
+		"node_modules/cli-table3/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/cli-table3/node_modules/emoji-regex": {
@@ -2302,6 +1990,18 @@
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
 				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cli-table3/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -2337,6 +2037,15 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/cliui/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/cliui/node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -2366,6 +2075,18 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/cliui/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/code-excerpt": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
@@ -2379,21 +2100,18 @@
 			}
 		},
 		"node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
 			"dev": true,
 			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
+				"color-name": "1.1.3"
 			}
 		},
 		"node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
 			"dev": true
 		},
 		"node_modules/color-support": {
@@ -2424,8 +2142,7 @@
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
 		},
 		"node_modules/concordance": {
 			"version": "5.0.4",
@@ -2608,7 +2325,6 @@
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
 			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-			"dev": true,
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -2670,12 +2386,11 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
 			"dependencies": {
-				"ms": "2.1.2"
+				"ms": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=6.0"
@@ -2698,8 +2413,7 @@
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-			"dev": true
+			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
 		},
 		"node_modules/delegates": {
 			"version": "1.0.0",
@@ -2714,9 +2428,9 @@
 			"dev": true
 		},
 		"node_modules/detect-libc": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
-			"integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+			"integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
 			"dev": true,
 			"engines": {
 				"node": ">=8"
@@ -2755,36 +2469,6 @@
 				"readable-stream": "^2.0.2"
 			}
 		},
-		"node_modules/duplexer2/node_modules/readable-stream": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-			"dev": true,
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/duplexer2/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"node_modules/duplexer2/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
 		"node_modules/emittery": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/emittery/-/emittery-1.0.3.tgz",
@@ -2798,9 +2482,9 @@
 			}
 		},
 		"node_modules/emoji-regex": {
-			"version": "10.3.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
-			"integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+			"integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
 			"dev": true
 		},
 		"node_modules/emojilib": {
@@ -2810,9 +2494,9 @@
 			"dev": true
 		},
 		"node_modules/env-ci": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/env-ci/-/env-ci-11.0.0.tgz",
-			"integrity": "sha512-apikxMgkipkgTvMdRT9MNqWx5VLOci79F4VBd7Op/7OPjjoanjdAvn6fglMCCEf/1bAh8eOiuEVCUs4V3qP3nQ==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/env-ci/-/env-ci-11.1.0.tgz",
+			"integrity": "sha512-Z8dnwSDbV1XYM9SBF2J0GcNVvmfmfh3a49qddGIROhBoVro6MZVTji15z/sJbQ2ko2ei8n988EU1wzoLU/tF+g==",
 			"dev": true,
 			"dependencies": {
 				"execa": "^8.0.0",
@@ -2965,6 +2649,18 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/environment": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+			"integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -2975,9 +2671,9 @@
 			}
 		},
 		"node_modules/escalade": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-			"integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -2987,7 +2683,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-			"dev": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -2999,7 +2694,6 @@
 			"version": "9.4.0",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.4.0.tgz",
 			"integrity": "sha512-sjc7Y8cUD1IlwYcTS9qPSvGjAC8Ne9LctpxKKu3x/1IC9bnOg98Zy6GxEJUfr1NojMgVPlyANXYns8oE2c1TAA==",
-			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
@@ -3047,10 +2741,9 @@
 			}
 		},
 		"node_modules/eslint-scope": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.0.1.tgz",
-			"integrity": "sha512-pL8XjgP4ZOmmwfFE8mEhSxA7ZY4C+LWyqjQ3o4yWkkmD0qcMT9kkW3zWHOczhWcjTSgqycYAgwSlXvZltv65og==",
-			"dev": true,
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.1.0.tgz",
+			"integrity": "sha512-14dSvlhaVhKKsa9Fx1l8A17s7ah7Ef7wCakJ10LYk6+GYmP9yDti2oq2SEwcyndt6knfcZyhyxwY3i9yL78EQw==",
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
@@ -3063,51 +2756,97 @@
 			}
 		},
 		"node_modules/eslint-visitor-keys": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-			"dev": true,
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint/node_modules/eslint-visitor-keys": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
-			"integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
-			"dev": true,
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.1.0.tgz",
+			"integrity": "sha512-Q7lok0mqMUSf5a/AdAZkA5a/gHcO6snwQClVNNvFKCAVlxXucdU8pKydU5ZVZjBx5xr37vGbFFWtLQYreLzrZg==",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint/node_modules/@eslint/js": {
+			"version": "9.4.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.4.0.tgz",
+			"integrity": "sha512-fdI7VJjP3Rvc70lC4xkFXHB0fiPeojiL1PxVG6t1ZvXQrarj893PweuBTujxDUFk0Fxj4R7PIIAZ/aiiyZPZcg==",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/eslint/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/eslint/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/eslint/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/eslint/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/eslint/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+		},
+		"node_modules/eslint/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/espree": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-10.0.1.tgz",
-			"integrity": "sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==",
-			"dev": true,
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.2.0.tgz",
+			"integrity": "sha512-upbkBJbckcCNBDBDXEbuhjbP68n+scUd3k/U2EkyM9nw+I/jPiL4cLF/Al06CF96wRltFda16sxDFrxsI1v0/g==",
 			"dependencies": {
-				"acorn": "^8.11.3",
+				"acorn": "^8.12.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^4.0.0"
+				"eslint-visitor-keys": "^4.1.0"
 			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/espree/node_modules/eslint-visitor-keys": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
-			"integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
-			"dev": true,
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
@@ -3129,10 +2868,9 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
-			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
-			"dev": true,
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
 			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
@@ -3144,7 +2882,6 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-			"dev": true,
 			"dependencies": {
 				"estraverse": "^5.2.0"
 			},
@@ -3156,7 +2893,6 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-			"dev": true,
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -3171,7 +2907,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -3214,8 +2949,7 @@
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
 		"node_modules/fast-diff": {
 			"version": "1.3.0",
@@ -3227,7 +2961,6 @@
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
 			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-			"dev": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
@@ -3243,7 +2976,6 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
 			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-			"dev": true,
 			"dependencies": {
 				"is-glob": "^4.0.1"
 			},
@@ -3254,20 +2986,17 @@
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
 		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-			"dev": true
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
 		},
 		"node_modules/fastq": {
 			"version": "1.17.1",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
 			"integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
-			"dev": true,
 			"dependencies": {
 				"reusify": "^1.0.4"
 			}
@@ -3277,7 +3006,6 @@
 			"resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
 			"integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"is-unicode-supported": "^2.0.0"
 			},
@@ -3292,7 +3020,6 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
 			"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-			"dev": true,
 			"dependencies": {
 				"flat-cache": "^4.0.0"
 			},
@@ -3310,7 +3037,6 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
 			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"dev": true,
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
 			},
@@ -3322,7 +3048,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-			"dev": true,
 			"dependencies": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -3366,7 +3091,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
 			"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-			"dev": true,
 			"dependencies": {
 				"flatted": "^3.2.9",
 				"keyv": "^4.5.4"
@@ -3378,8 +3102,7 @@
 		"node_modules/flatted": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-			"dev": true
+			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
 		},
 		"node_modules/from2": {
 			"version": "2.3.0",
@@ -3389,36 +3112,6 @@
 			"dependencies": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
-			}
-		},
-		"node_modules/from2/node_modules/readable-stream": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-			"dev": true,
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/from2/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"node_modules/from2/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
 			}
 		},
 		"node_modules/fs-extra": {
@@ -3465,19 +3158,10 @@
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
 		},
-		"node_modules/function-bind": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/function-timeout": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.1.tgz",
-			"integrity": "sha512-6yPMImFFuaMPNaTMTBuolA8EanHJWF5Vju0NHpObRURT105J6x1Mf2a7J4P7Sqk2xDxv24N5L0RatEhTBhNmdA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+			"integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
 			"dev": true,
 			"engines": {
 				"node": ">=18"
@@ -3490,6 +3174,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
 			"integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+			"deprecated": "This package is no longer supported.",
 			"dev": true,
 			"dependencies": {
 				"aproba": "^1.0.3 || ^2.0.0",
@@ -3504,6 +3189,15 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/gauge/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/gauge/node_modules/emoji-regex": {
@@ -3535,6 +3229,18 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/gauge/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -3545,9 +3251,9 @@
 			}
 		},
 		"node_modules/get-east-asian-width": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
-			"integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+			"integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=18"
@@ -3569,9 +3275,9 @@
 			}
 		},
 		"node_modules/git-log-parser": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.0.tgz",
-			"integrity": "sha512-rnCVNfkTL8tdNryFuaY0fYiBWEBcgF748O6ZI61rslBvr2o7U65c2/6npCRqH40vuAhtgtDiqLTJjBVdrejCzA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.1.tgz",
+			"integrity": "sha512-PI+sPDvHXNPl5WNOErAK05s3j0lgwUzMN6o8cyQrDaKfT3qd7TmNJKeXX+SknI5I0QhG5fVPAEwSY4tRGDtYoQ==",
 			"dev": true,
 			"dependencies": {
 				"argv-formatter": "~1.0.0",
@@ -3579,7 +3285,7 @@
 				"split2": "~1.0.0",
 				"stream-combiner2": "~1.1.1",
 				"through2": "~2.0.0",
-				"traverse": "~0.6.6"
+				"traverse": "0.6.8"
 			}
 		},
 		"node_modules/git-log-parser/node_modules/split2": {
@@ -3595,6 +3301,7 @@
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
 			"dev": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
@@ -3615,7 +3322,6 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
 			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-			"dev": true,
 			"dependencies": {
 				"is-glob": "^4.0.3"
 			},
@@ -3627,7 +3333,6 @@
 			"version": "14.0.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
 			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -3636,20 +3341,19 @@
 			}
 		},
 		"node_modules/globby": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+			"version": "13.2.2",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
+			"integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
 			"dev": true,
 			"dependencies": {
-				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.2.9",
-				"ignore": "^5.2.0",
+				"fast-glob": "^3.3.0",
+				"ignore": "^5.2.4",
 				"merge2": "^1.4.1",
-				"slash": "^3.0.0"
+				"slash": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -3664,8 +3368,7 @@
 		"node_modules/graphemer": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-			"dev": true
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
 		},
 		"node_modules/handlebars": {
 			"version": "4.7.8",
@@ -3692,7 +3395,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -3702,18 +3404,6 @@
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
 			"dev": true
-		},
-		"node_modules/hasown": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz",
-			"integrity": "sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==",
-			"dev": true,
-			"dependencies": {
-				"function-bind": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
 		},
 		"node_modules/highlight.js": {
 			"version": "10.7.3",
@@ -3737,24 +3427,15 @@
 			}
 		},
 		"node_modules/hosted-git-info": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
-			"integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^10.0.1"
 			},
 			"engines": {
 				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/hosted-git-info/node_modules/lru-cache": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
-			"integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
-			"dev": true,
-			"engines": {
-				"node": "14 || >=16.14"
 			}
 		},
 		"node_modules/http-proxy-agent": {
@@ -3770,29 +3451,17 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/http-proxy-agent/node_modules/agent-base": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-			"integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-			"dev": true,
-			"dependencies": {
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/https-proxy-agent": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+			"integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
 			"dev": true,
 			"dependencies": {
-				"agent-base": "6",
+				"agent-base": "^7.0.2",
 				"debug": "4"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": ">= 14"
 			}
 		},
 		"node_modules/human-signals": {
@@ -3805,10 +3474,9 @@
 			}
 		},
 		"node_modules/ignore": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
-			"dev": true,
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"engines": {
 				"node": ">= 4"
 			}
@@ -3826,7 +3494,6 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
 			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-			"dev": true,
 			"dependencies": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
@@ -3836,6 +3503,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/import-fresh/node_modules/resolve-from": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/import-from": {
@@ -3851,9 +3526,9 @@
 			}
 		},
 		"node_modules/import-from-esm": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.3.3.tgz",
-			"integrity": "sha512-U3Qt/CyfFpTUv6LOP2jRTLYjphH6zg3okMfHbyqRa/W2w6hr8OsJWVggNlR4jxuojQy81TgTJTxgSkyoteRGMQ==",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.3.4.tgz",
+			"integrity": "sha512-7EyUlPFC0HOlBDpUFGfYstsU7XHxZJKAAMzCT8wZ0hMW7b+hG51LIKTDcsgtz8Pu6YC0HqRVbX+rVUtsGMUKvg==",
 			"dev": true,
 			"dependencies": {
 				"debug": "^4.3.4",
@@ -3864,9 +3539,9 @@
 			}
 		},
 		"node_modules/import-meta-resolve": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.0.0.tgz",
-			"integrity": "sha512-okYUR7ZQPH+efeuMJGlq4f8ubUgO50kByRPyt/Cy1Io4PSRsPjxME+YlVaCOx+NIToW7hCsZNFJyTPFFKepRSA==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+			"integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
 			"dev": true,
 			"funding": {
 				"type": "github",
@@ -3877,21 +3552,17 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.8.19"
 			}
 		},
 		"node_modules/indent-string": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
 			"dev": true,
 			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=8"
 			}
 		},
 		"node_modules/index-to-position": {
@@ -3910,6 +3581,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
 			"dev": true,
 			"dependencies": {
 				"once": "^1.3.0",
@@ -3959,23 +3631,10 @@
 			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
 			"dev": true
 		},
-		"node_modules/is-core-module": {
-			"version": "2.13.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-			"integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
-			"dev": true,
-			"dependencies": {
-				"hasown": "^2.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -3996,7 +3655,6 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-			"dev": true,
 			"dependencies": {
 				"is-extglob": "^2.1.1"
 			},
@@ -4008,7 +3666,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.12.0"
 			}
@@ -4026,7 +3683,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -4036,7 +3692,6 @@
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
 			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			},
@@ -4084,9 +3739,9 @@
 			}
 		},
 		"node_modules/is-unicode-supported": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.0.0.tgz",
-			"integrity": "sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+			"integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=18"
@@ -4104,8 +3759,7 @@
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
 		},
 		"node_modules/issue-parser": {
 			"version": "6.0.0",
@@ -4151,7 +3805,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-			"dev": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -4162,8 +3815,7 @@
 		"node_modules/json-buffer": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-			"dev": true
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
 		},
 		"node_modules/json-parse-better-errors": {
 			"version": "1.0.2",
@@ -4172,9 +3824,9 @@
 			"dev": true
 		},
 		"node_modules/json-parse-even-better-errors": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.1.tgz",
-			"integrity": "sha512-aatBvbL26wVUCLmbWdCpeu9iF5wOyWpagiKkInA+kfws3sWdBrTnsvN2CKcyCYyUrc7rebNBlK6+kteg7ksecg==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
+			"integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
 			"dev": true,
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -4183,14 +3835,12 @@
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-			"dev": true
+			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
 		},
 		"node_modules/json-stringify-safe": {
 			"version": "5.0.1",
@@ -4239,7 +3889,6 @@
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
 			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-			"dev": true,
 			"dependencies": {
 				"json-buffer": "3.0.1"
 			}
@@ -4248,7 +3897,6 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
 			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-			"dev": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
@@ -4282,7 +3930,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-			"dev": true,
 			"dependencies": {
 				"p-locate": "^5.0.0"
 			},
@@ -4332,8 +3979,7 @@
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
 		},
 		"node_modules/lodash.uniqby": {
 			"version": "4.7.0",
@@ -4342,16 +3988,10 @@
 			"dev": true
 		},
 		"node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true
 		},
 		"node_modules/make-dir": {
 			"version": "3.1.0",
@@ -4378,9 +4018,9 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-12.0.0.tgz",
-			"integrity": "sha512-Vkwtq9rLqXryZnWaQc86+FHLC6tr/fycMfYAhiOIXkrNmeGAyhSxjqu0Rs1i0bBqw5u0S7+lV9fdH2ZSVaoa0w==",
+			"version": "12.0.2",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+			"integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
 			"dev": true,
 			"bin": {
 				"marked": "bin/marked.js"
@@ -4390,15 +4030,15 @@
 			}
 		},
 		"node_modules/marked-terminal": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.0.0.tgz",
-			"integrity": "sha512-sNEx8nn9Ktcm6pL0TnRz8tnXq/mSS0Q1FRSwJOAqw4lAB4l49UeDf85Gm1n9RPFm5qurCPjwi1StAQT2XExhZw==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.1.0.tgz",
+			"integrity": "sha512-+pvwa14KZL74MVXjYdPR3nSInhGhNvPce/3mqLVZT2oUvt654sL1XImFuLZ1pkA866IYZ3ikDTOFUIC7XzpZZg==",
 			"dev": true,
 			"dependencies": {
-				"ansi-escapes": "^6.2.0",
+				"ansi-escapes": "^7.0.0",
 				"chalk": "^5.3.0",
 				"cli-highlight": "^2.1.11",
-				"cli-table3": "^0.6.3",
+				"cli-table3": "^0.6.5",
 				"node-emoji": "^2.1.3",
 				"supports-hyperlinks": "^3.0.0"
 			},
@@ -4406,19 +4046,7 @@
 				"node": ">=16.0.0"
 			},
 			"peerDependencies": {
-				"marked": ">=1 <13"
-			}
-		},
-		"node_modules/marked-terminal/node_modules/chalk": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-			"dev": true,
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
+				"marked": ">=1 <14"
 			}
 		},
 		"node_modules/matcher": {
@@ -4497,7 +4125,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-			"dev": true,
 			"engines": {
 				"node": ">= 8"
 			}
@@ -4506,13 +4133,23 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
 			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"dev": true,
 			"dependencies": {
 				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/micromatch/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/mime": {
@@ -4537,9 +4174,9 @@
 			}
 		},
 		"node_modules/mimic-function": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.0.tgz",
-			"integrity": "sha512-RBfQ+9X9DpXdEoK7Bu+KeEU6vFhumEIiXKWECPzRBmDserEq4uR2b/VCm0LwpMSosoq2k+Zuxj/GzOr0Fn6h/g==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+			"integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
 			"dev": true,
 			"engines": {
 				"node": ">=18"
@@ -4552,7 +4189,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -4616,10 +4252,9 @@
 			}
 		},
 		"node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
 		},
 		"node_modules/mz": {
 			"version": "2.7.0",
@@ -4635,8 +4270,7 @@
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-			"dev": true
+			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
 		},
 		"node_modules/neo-async": {
 			"version": "2.6.2",
@@ -4686,9 +4320,9 @@
 			}
 		},
 		"node_modules/node-gyp-build": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
-			"integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.2.tgz",
+			"integrity": "sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==",
 			"dev": true,
 			"bin": {
 				"node-gyp-build": "bin.js",
@@ -4721,13 +4355,12 @@
 			}
 		},
 		"node_modules/normalize-package-data": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.0.tgz",
-			"integrity": "sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
 			"dev": true,
 			"dependencies": {
 				"hosted-git-info": "^7.0.0",
-				"is-core-module": "^2.8.1",
 				"semver": "^7.3.5",
 				"validate-npm-package-license": "^3.0.4"
 			},
@@ -4736,9 +4369,9 @@
 			}
 		},
 		"node_modules/normalize-url": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
-			"integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
+			"integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==",
 			"dev": true,
 			"engines": {
 				"node": ">=14.16"
@@ -4748,9 +4381,9 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "10.8.3",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-10.8.3.tgz",
-			"integrity": "sha512-0IQlyAYvVtQ7uOhDFYZCGK8kkut2nh8cpAdA9E6FvRSJaTgtZRZgNjlC5ZCct//L73ygrpY93CxXpRJDtNqPVg==",
+			"version": "10.9.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-10.9.0.tgz",
+			"integrity": "sha512-ZanDioFylI9helNhl2LNd+ErmVD+H5I53ry41ixlLyCBgkuYb+58CvbAp99hW+zr5L9W4X7CchSoeqKdngOLSw==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
@@ -4822,20 +4455,27 @@
 				"write-file-atomic"
 			],
 			"dev": true,
+			"workspaces": [
+				"docs",
+				"smoke-tests",
+				"mock-globals",
+				"mock-registry",
+				"workspaces/*"
+			],
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^7.5.4",
-				"@npmcli/config": "^8.3.4",
-				"@npmcli/fs": "^3.1.1",
-				"@npmcli/map-workspaces": "^3.0.6",
-				"@npmcli/package-json": "^5.2.0",
-				"@npmcli/promise-spawn": "^7.0.2",
-				"@npmcli/redact": "^2.0.1",
-				"@npmcli/run-script": "^8.1.0",
+				"@npmcli/arborist": "^8.0.0",
+				"@npmcli/config": "^9.0.0",
+				"@npmcli/fs": "^4.0.0",
+				"@npmcli/map-workspaces": "^4.0.1",
+				"@npmcli/package-json": "^6.0.1",
+				"@npmcli/promise-spawn": "^8.0.1",
+				"@npmcli/redact": "^3.0.0",
+				"@npmcli/run-script": "^9.0.1",
 				"@sigstore/tuf": "^2.3.4",
-				"abbrev": "^2.0.0",
+				"abbrev": "^3.0.0",
 				"archy": "~1.0.0",
-				"cacache": "^18.0.4",
+				"cacache": "^19.0.1",
 				"chalk": "^5.3.0",
 				"ci-info": "^4.0.0",
 				"cli-columns": "^4.0.0",
@@ -4843,54 +4483,54 @@
 				"fs-minipass": "^3.0.3",
 				"glob": "^10.4.5",
 				"graceful-fs": "^4.2.11",
-				"hosted-git-info": "^7.0.2",
-				"ini": "^4.1.3",
-				"init-package-json": "^6.0.3",
+				"hosted-git-info": "^8.0.0",
+				"ini": "^5.0.0",
+				"init-package-json": "^7.0.1",
 				"is-cidr": "^5.1.0",
-				"json-parse-even-better-errors": "^3.0.2",
-				"libnpmaccess": "^8.0.6",
-				"libnpmdiff": "^6.1.4",
-				"libnpmexec": "^8.1.4",
-				"libnpmfund": "^5.0.12",
-				"libnpmhook": "^10.0.5",
-				"libnpmorg": "^6.0.6",
-				"libnpmpack": "^7.0.4",
-				"libnpmpublish": "^9.0.9",
-				"libnpmsearch": "^7.0.6",
-				"libnpmteam": "^6.0.5",
-				"libnpmversion": "^6.0.3",
-				"make-fetch-happen": "^13.0.1",
+				"json-parse-even-better-errors": "^4.0.0",
+				"libnpmaccess": "^9.0.0",
+				"libnpmdiff": "^7.0.0",
+				"libnpmexec": "^9.0.0",
+				"libnpmfund": "^6.0.0",
+				"libnpmhook": "^11.0.0",
+				"libnpmorg": "^7.0.0",
+				"libnpmpack": "^8.0.0",
+				"libnpmpublish": "^10.0.0",
+				"libnpmsearch": "^8.0.0",
+				"libnpmteam": "^7.0.0",
+				"libnpmversion": "^7.0.0",
+				"make-fetch-happen": "^14.0.1",
 				"minimatch": "^9.0.5",
 				"minipass": "^7.1.1",
 				"minipass-pipeline": "^1.2.4",
 				"ms": "^2.1.2",
 				"node-gyp": "^10.2.0",
-				"nopt": "^7.2.1",
-				"normalize-package-data": "^6.0.2",
-				"npm-audit-report": "^5.0.0",
-				"npm-install-checks": "^6.3.0",
-				"npm-package-arg": "^11.0.3",
-				"npm-pick-manifest": "^9.1.0",
-				"npm-profile": "^10.0.0",
-				"npm-registry-fetch": "^17.1.0",
-				"npm-user-validate": "^2.0.1",
+				"nopt": "^8.0.0",
+				"normalize-package-data": "^7.0.0",
+				"npm-audit-report": "^6.0.0",
+				"npm-install-checks": "^7.1.0",
+				"npm-package-arg": "^12.0.0",
+				"npm-pick-manifest": "^10.0.0",
+				"npm-profile": "^11.0.1",
+				"npm-registry-fetch": "^18.0.1",
+				"npm-user-validate": "^3.0.0",
 				"p-map": "^4.0.0",
-				"pacote": "^18.0.6",
-				"parse-conflict-json": "^3.0.1",
-				"proc-log": "^4.2.0",
+				"pacote": "^19.0.0",
+				"parse-conflict-json": "^4.0.0",
+				"proc-log": "^5.0.0",
 				"qrcode-terminal": "^0.12.0",
-				"read": "^3.0.1",
+				"read": "^4.0.0",
 				"semver": "^7.6.3",
 				"spdx-expression-parse": "^4.0.0",
-				"ssri": "^10.0.6",
+				"ssri": "^12.0.0",
 				"supports-color": "^9.4.0",
 				"tar": "^6.2.1",
 				"text-table": "~0.2.0",
 				"tiny-relative-date": "^1.3.0",
 				"treeverse": "^3.0.0",
-				"validate-npm-package-name": "^5.0.1",
-				"which": "^4.0.0",
-				"write-file-atomic": "^5.0.1"
+				"validate-npm-package-name": "^6.0.0",
+				"which": "^5.0.0",
+				"write-file-atomic": "^6.0.0"
 			},
 			"bin": {
 				"npm": "bin/npm-cli.js",
@@ -4979,6 +4619,18 @@
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
+		"node_modules/npm/node_modules/@isaacs/fs-minipass": {
+			"version": "4.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.4"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
 		"node_modules/npm/node_modules/@isaacs/string-locale-compare": {
 			"version": "1.1.0",
 			"dev": true,
@@ -4986,7 +4638,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/@npmcli/agent": {
-			"version": "2.2.2",
+			"version": "3.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -4998,48 +4650,48 @@
 				"socks-proxy-agent": "^8.0.3"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "7.5.4",
+			"version": "8.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/fs": "^3.1.1",
-				"@npmcli/installed-package-contents": "^2.1.0",
-				"@npmcli/map-workspaces": "^3.0.2",
-				"@npmcli/metavuln-calculator": "^7.1.1",
-				"@npmcli/name-from-folder": "^2.0.0",
-				"@npmcli/node-gyp": "^3.0.0",
-				"@npmcli/package-json": "^5.1.0",
-				"@npmcli/query": "^3.1.0",
-				"@npmcli/redact": "^2.0.0",
-				"@npmcli/run-script": "^8.1.0",
-				"bin-links": "^4.0.4",
-				"cacache": "^18.0.3",
+				"@npmcli/fs": "^4.0.0",
+				"@npmcli/installed-package-contents": "^3.0.0",
+				"@npmcli/map-workspaces": "^4.0.1",
+				"@npmcli/metavuln-calculator": "^8.0.0",
+				"@npmcli/name-from-folder": "^3.0.0",
+				"@npmcli/node-gyp": "^4.0.0",
+				"@npmcli/package-json": "^6.0.1",
+				"@npmcli/query": "^4.0.0",
+				"@npmcli/redact": "^3.0.0",
+				"@npmcli/run-script": "^9.0.1",
+				"bin-links": "^5.0.0",
+				"cacache": "^19.0.1",
 				"common-ancestor-path": "^1.0.1",
-				"hosted-git-info": "^7.0.2",
-				"json-parse-even-better-errors": "^3.0.2",
+				"hosted-git-info": "^8.0.0",
+				"json-parse-even-better-errors": "^4.0.0",
 				"json-stringify-nice": "^1.1.4",
 				"lru-cache": "^10.2.2",
 				"minimatch": "^9.0.4",
-				"nopt": "^7.2.1",
-				"npm-install-checks": "^6.2.0",
-				"npm-package-arg": "^11.0.2",
-				"npm-pick-manifest": "^9.0.1",
-				"npm-registry-fetch": "^17.0.1",
-				"pacote": "^18.0.6",
-				"parse-conflict-json": "^3.0.0",
-				"proc-log": "^4.2.0",
-				"proggy": "^2.0.0",
+				"nopt": "^8.0.0",
+				"npm-install-checks": "^7.1.0",
+				"npm-package-arg": "^12.0.0",
+				"npm-pick-manifest": "^10.0.0",
+				"npm-registry-fetch": "^18.0.1",
+				"pacote": "^19.0.0",
+				"parse-conflict-json": "^4.0.0",
+				"proc-log": "^5.0.0",
+				"proggy": "^3.0.0",
 				"promise-all-reject-late": "^1.0.0",
 				"promise-call-limit": "^3.0.1",
-				"read-package-json-fast": "^3.0.2",
+				"read-package-json-fast": "^4.0.0",
 				"semver": "^7.3.7",
-				"ssri": "^10.0.6",
+				"ssri": "^12.0.0",
 				"treeverse": "^3.0.0",
 				"walk-up-path": "^3.0.1"
 			},
@@ -5047,30 +4699,30 @@
 				"arborist": "bin/index.js"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/config": {
-			"version": "8.3.4",
+			"version": "9.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/map-workspaces": "^3.0.2",
-				"@npmcli/package-json": "^5.1.1",
+				"@npmcli/map-workspaces": "^4.0.1",
+				"@npmcli/package-json": "^6.0.1",
 				"ci-info": "^4.0.0",
-				"ini": "^4.1.2",
-				"nopt": "^7.2.1",
-				"proc-log": "^4.2.0",
+				"ini": "^5.0.0",
+				"nopt": "^8.0.0",
+				"proc-log": "^5.0.0",
 				"semver": "^7.3.5",
 				"walk-up-path": "^3.0.1"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/fs": {
-			"version": "3.1.1",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -5078,160 +4730,160 @@
 				"semver": "^7.3.5"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/git": {
-			"version": "5.0.8",
+			"version": "6.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/promise-spawn": "^7.0.0",
-				"ini": "^4.1.3",
+				"@npmcli/promise-spawn": "^8.0.0",
+				"ini": "^5.0.0",
 				"lru-cache": "^10.0.1",
-				"npm-pick-manifest": "^9.0.0",
-				"proc-log": "^4.0.0",
+				"npm-pick-manifest": "^10.0.0",
+				"proc-log": "^5.0.0",
 				"promise-inflight": "^1.0.1",
 				"promise-retry": "^2.0.1",
 				"semver": "^7.3.5",
-				"which": "^4.0.0"
+				"which": "^5.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-			"version": "2.1.0",
+			"version": "3.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-bundled": "^3.0.0",
-				"npm-normalize-package-bin": "^3.0.0"
+				"npm-bundled": "^4.0.0",
+				"npm-normalize-package-bin": "^4.0.0"
 			},
 			"bin": {
 				"installed-package-contents": "bin/index.js"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/map-workspaces": {
-			"version": "3.0.6",
+			"version": "4.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/name-from-folder": "^2.0.0",
+				"@npmcli/name-from-folder": "^3.0.0",
+				"@npmcli/package-json": "^6.0.0",
 				"glob": "^10.2.2",
-				"minimatch": "^9.0.0",
-				"read-package-json-fast": "^3.0.0"
+				"minimatch": "^9.0.0"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-			"version": "7.1.1",
+			"version": "8.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"cacache": "^18.0.0",
-				"json-parse-even-better-errors": "^3.0.0",
-				"pacote": "^18.0.0",
-				"proc-log": "^4.1.0",
+				"cacache": "^19.0.0",
+				"json-parse-even-better-errors": "^4.0.0",
+				"pacote": "^19.0.0",
+				"proc-log": "^5.0.0",
 				"semver": "^7.3.5"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/name-from-folder": {
-			"version": "2.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/@npmcli/node-gyp": {
 			"version": "3.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/node-gyp": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/package-json": {
-			"version": "5.2.0",
+			"version": "6.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/git": "^5.0.0",
+				"@npmcli/git": "^6.0.0",
 				"glob": "^10.2.2",
-				"hosted-git-info": "^7.0.0",
-				"json-parse-even-better-errors": "^3.0.0",
-				"normalize-package-data": "^6.0.0",
-				"proc-log": "^4.0.0",
+				"hosted-git-info": "^8.0.0",
+				"json-parse-even-better-errors": "^4.0.0",
+				"normalize-package-data": "^7.0.0",
+				"proc-log": "^5.0.0",
 				"semver": "^7.5.3"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/promise-spawn": {
-			"version": "7.0.2",
+			"version": "8.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"which": "^4.0.0"
+				"which": "^5.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/query": {
-			"version": "3.1.0",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"postcss-selector-parser": "^6.0.10"
+				"postcss-selector-parser": "^6.1.2"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/redact": {
-			"version": "2.0.1",
+			"version": "3.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/run-script": {
-			"version": "8.1.0",
+			"version": "9.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/node-gyp": "^3.0.0",
-				"@npmcli/package-json": "^5.0.0",
-				"@npmcli/promise-spawn": "^7.0.0",
+				"@npmcli/node-gyp": "^4.0.0",
+				"@npmcli/package-json": "^6.0.0",
+				"@npmcli/promise-spawn": "^8.0.0",
 				"node-gyp": "^10.0.0",
-				"proc-log": "^4.0.0",
-				"which": "^4.0.0"
+				"proc-log": "^5.0.0",
+				"which": "^5.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/@pkgjs/parseargs": {
@@ -5291,6 +4943,142 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
+		"node_modules/npm/node_modules/@sigstore/sign/node_modules/@npmcli/agent": {
+			"version": "2.2.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.1",
+				"lru-cache": "^10.0.1",
+				"socks-proxy-agent": "^8.0.3"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/sign/node_modules/@npmcli/fs": {
+			"version": "3.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/sign/node_modules/cacache": {
+			"version": "18.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/fs": "^3.1.0",
+				"fs-minipass": "^3.0.0",
+				"glob": "^10.2.2",
+				"lru-cache": "^10.0.1",
+				"minipass": "^7.0.3",
+				"minipass-collect": "^2.0.1",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"p-map": "^4.0.0",
+				"ssri": "^10.0.0",
+				"tar": "^6.1.11",
+				"unique-filename": "^3.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/sign/node_modules/make-fetch-happen": {
+			"version": "13.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/agent": "^2.0.0",
+				"cacache": "^18.0.0",
+				"http-cache-semantics": "^4.1.1",
+				"is-lambda": "^1.0.1",
+				"minipass": "^7.0.2",
+				"minipass-fetch": "^3.0.0",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"negotiator": "^0.6.3",
+				"proc-log": "^4.2.0",
+				"promise-retry": "^2.0.1",
+				"ssri": "^10.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/sign/node_modules/minipass-fetch": {
+			"version": "3.0.5",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^7.0.3",
+				"minipass-sized": "^1.0.3",
+				"minizlib": "^2.1.2"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			},
+			"optionalDependencies": {
+				"encoding": "^0.1.13"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/sign/node_modules/proc-log": {
+			"version": "4.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/sign/node_modules/ssri": {
+			"version": "10.0.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.3"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/sign/node_modules/unique-filename": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"unique-slug": "^4.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/sign/node_modules/unique-slug": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"imurmurhash": "^0.1.4"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
 		"node_modules/npm/node_modules/@sigstore/tuf": {
 			"version": "2.3.4",
 			"dev": true,
@@ -5341,12 +5129,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/abbrev": {
-			"version": "2.0.0",
+			"version": "3.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/agent-base": {
@@ -5414,18 +5202,19 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/bin-links": {
-			"version": "4.0.4",
+			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"cmd-shim": "^6.0.0",
-				"npm-normalize-package-bin": "^3.0.0",
-				"read-cmd-shim": "^4.0.0",
-				"write-file-atomic": "^5.0.0"
+				"cmd-shim": "^7.0.0",
+				"npm-normalize-package-bin": "^4.0.0",
+				"proc-log": "^5.0.0",
+				"read-cmd-shim": "^5.0.0",
+				"write-file-atomic": "^6.0.0"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/binary-extensions": {
@@ -5450,12 +5239,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/cacache": {
-			"version": "18.0.4",
+			"version": "19.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/fs": "^3.1.0",
+				"@npmcli/fs": "^4.0.0",
 				"fs-minipass": "^3.0.0",
 				"glob": "^10.2.2",
 				"lru-cache": "^10.0.1",
@@ -5463,13 +5252,88 @@
 				"minipass-collect": "^2.0.1",
 				"minipass-flush": "^1.0.5",
 				"minipass-pipeline": "^1.2.4",
-				"p-map": "^4.0.0",
-				"ssri": "^10.0.0",
-				"tar": "^6.1.11",
-				"unique-filename": "^3.0.0"
+				"p-map": "^7.0.2",
+				"ssri": "^12.0.0",
+				"tar": "^7.4.3",
+				"unique-filename": "^4.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/cacache/node_modules/chownr": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/npm/node_modules/cacache/node_modules/minizlib": {
+			"version": "3.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^7.0.4",
+				"rimraf": "^5.0.5"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/npm/node_modules/cacache/node_modules/mkdirp": {
+			"version": "3.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"bin": {
+				"mkdirp": "dist/cjs/src/bin.js"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/cacache/node_modules/p-map": {
+			"version": "7.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm/node_modules/cacache/node_modules/tar": {
+			"version": "7.4.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@isaacs/fs-minipass": "^4.0.0",
+				"chownr": "^3.0.0",
+				"minipass": "^7.1.2",
+				"minizlib": "^3.0.1",
+				"mkdirp": "^3.0.1",
+				"yallist": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/npm/node_modules/cacache/node_modules/yallist": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/npm/node_modules/chalk": {
@@ -5543,12 +5407,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/cmd-shim": {
-			"version": "6.0.3",
+			"version": "7.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/color-convert": {
@@ -5755,7 +5619,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/hosted-git-info": {
-			"version": "7.0.2",
+			"version": "8.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -5763,7 +5627,7 @@
 				"lru-cache": "^10.0.1"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/http-cache-semantics": {
@@ -5812,7 +5676,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/ignore-walk": {
-			"version": "6.0.5",
+			"version": "7.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -5820,7 +5684,7 @@
 				"minimatch": "^9.0.0"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/imurmurhash": {
@@ -5842,30 +5706,30 @@
 			}
 		},
 		"node_modules/npm/node_modules/ini": {
-			"version": "4.1.3",
+			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/init-package-json": {
-			"version": "6.0.3",
+			"version": "7.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/package-json": "^5.0.0",
-				"npm-package-arg": "^11.0.0",
-				"promzard": "^1.0.0",
-				"read": "^3.0.1",
+				"@npmcli/package-json": "^6.0.0",
+				"npm-package-arg": "^12.0.0",
+				"promzard": "^2.0.0",
+				"read": "^4.0.0",
 				"semver": "^7.3.5",
 				"validate-npm-package-license": "^3.0.4",
-				"validate-npm-package-name": "^5.0.0"
+				"validate-npm-package-name": "^6.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/ip-address": {
@@ -5948,12 +5812,12 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/json-parse-even-better-errors": {
-			"version": "3.0.2",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/json-stringify-nice": {
@@ -5987,169 +5851,169 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/libnpmaccess": {
-			"version": "8.0.6",
+			"version": "9.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-package-arg": "^11.0.2",
-				"npm-registry-fetch": "^17.0.1"
+				"npm-package-arg": "^12.0.0",
+				"npm-registry-fetch": "^18.0.1"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmdiff": {
-			"version": "6.1.4",
+			"version": "7.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^7.5.4",
-				"@npmcli/installed-package-contents": "^2.1.0",
+				"@npmcli/arborist": "^8.0.0",
+				"@npmcli/installed-package-contents": "^3.0.0",
 				"binary-extensions": "^2.3.0",
 				"diff": "^5.1.0",
 				"minimatch": "^9.0.4",
-				"npm-package-arg": "^11.0.2",
-				"pacote": "^18.0.6",
+				"npm-package-arg": "^12.0.0",
+				"pacote": "^19.0.0",
 				"tar": "^6.2.1"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmexec": {
-			"version": "8.1.4",
+			"version": "9.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^7.5.4",
-				"@npmcli/run-script": "^8.1.0",
+				"@npmcli/arborist": "^8.0.0",
+				"@npmcli/run-script": "^9.0.1",
 				"ci-info": "^4.0.0",
-				"npm-package-arg": "^11.0.2",
-				"pacote": "^18.0.6",
-				"proc-log": "^4.2.0",
-				"read": "^3.0.1",
-				"read-package-json-fast": "^3.0.2",
+				"npm-package-arg": "^12.0.0",
+				"pacote": "^19.0.0",
+				"proc-log": "^5.0.0",
+				"read": "^4.0.0",
+				"read-package-json-fast": "^4.0.0",
 				"semver": "^7.3.7",
 				"walk-up-path": "^3.0.1"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmfund": {
-			"version": "5.0.12",
+			"version": "6.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^7.5.4"
+				"@npmcli/arborist": "^8.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmhook": {
-			"version": "10.0.5",
+			"version": "11.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"aproba": "^2.0.0",
-				"npm-registry-fetch": "^17.0.1"
+				"npm-registry-fetch": "^18.0.1"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmorg": {
-			"version": "6.0.6",
+			"version": "7.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"aproba": "^2.0.0",
-				"npm-registry-fetch": "^17.0.1"
+				"npm-registry-fetch": "^18.0.1"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpack": {
-			"version": "7.0.4",
+			"version": "8.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^7.5.4",
-				"@npmcli/run-script": "^8.1.0",
-				"npm-package-arg": "^11.0.2",
-				"pacote": "^18.0.6"
+				"@npmcli/arborist": "^8.0.0",
+				"@npmcli/run-script": "^9.0.1",
+				"npm-package-arg": "^12.0.0",
+				"pacote": "^19.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpublish": {
-			"version": "9.0.9",
+			"version": "10.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"ci-info": "^4.0.0",
-				"normalize-package-data": "^6.0.1",
-				"npm-package-arg": "^11.0.2",
-				"npm-registry-fetch": "^17.0.1",
-				"proc-log": "^4.2.0",
+				"normalize-package-data": "^7.0.0",
+				"npm-package-arg": "^12.0.0",
+				"npm-registry-fetch": "^18.0.1",
+				"proc-log": "^5.0.0",
 				"semver": "^7.3.7",
 				"sigstore": "^2.2.0",
-				"ssri": "^10.0.6"
+				"ssri": "^12.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmsearch": {
-			"version": "7.0.6",
+			"version": "8.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-registry-fetch": "^17.0.1"
+				"npm-registry-fetch": "^18.0.1"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmteam": {
-			"version": "6.0.5",
+			"version": "7.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"aproba": "^2.0.0",
-				"npm-registry-fetch": "^17.0.1"
+				"npm-registry-fetch": "^18.0.1"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/libnpmversion": {
-			"version": "6.0.3",
+			"version": "7.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/git": "^5.0.7",
-				"@npmcli/run-script": "^8.1.0",
-				"json-parse-even-better-errors": "^3.0.2",
-				"proc-log": "^4.2.0",
+				"@npmcli/git": "^6.0.1",
+				"@npmcli/run-script": "^9.0.1",
+				"json-parse-even-better-errors": "^4.0.0",
+				"proc-log": "^5.0.0",
 				"semver": "^7.3.7"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/lru-cache": {
@@ -6159,26 +6023,25 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/make-fetch-happen": {
-			"version": "13.0.1",
+			"version": "14.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/agent": "^2.0.0",
-				"cacache": "^18.0.0",
+				"@npmcli/agent": "^3.0.0",
+				"cacache": "^19.0.1",
 				"http-cache-semantics": "^4.1.1",
-				"is-lambda": "^1.0.1",
 				"minipass": "^7.0.2",
-				"minipass-fetch": "^3.0.0",
+				"minipass-fetch": "^4.0.0",
 				"minipass-flush": "^1.0.5",
 				"minipass-pipeline": "^1.2.4",
 				"negotiator": "^0.6.3",
-				"proc-log": "^4.2.0",
+				"proc-log": "^5.0.0",
 				"promise-retry": "^2.0.1",
-				"ssri": "^10.0.0"
+				"ssri": "^12.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/minimatch": {
@@ -6218,20 +6081,33 @@
 			}
 		},
 		"node_modules/npm/node_modules/minipass-fetch": {
-			"version": "3.0.5",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
 				"minipass": "^7.0.3",
 				"minipass-sized": "^1.0.3",
-				"minizlib": "^2.1.2"
+				"minizlib": "^3.0.1"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			},
 			"optionalDependencies": {
 				"encoding": "^0.1.13"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-fetch/node_modules/minizlib": {
+			"version": "3.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^7.0.4",
+				"rimraf": "^5.0.5"
+			},
+			"engines": {
+				"node": ">= 18"
 			}
 		},
 		"node_modules/npm/node_modules/minipass-flush": {
@@ -6350,12 +6226,12 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/mute-stream": {
-			"version": "1.0.0",
+			"version": "2.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/negotiator": {
@@ -6391,7 +6267,116 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
-		"node_modules/npm/node_modules/nopt": {
+		"node_modules/npm/node_modules/node-gyp/node_modules/@npmcli/agent": {
+			"version": "2.2.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.1",
+				"lru-cache": "^10.0.1",
+				"socks-proxy-agent": "^8.0.3"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/node-gyp/node_modules/@npmcli/fs": {
+			"version": "3.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/node-gyp/node_modules/abbrev": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/node-gyp/node_modules/cacache": {
+			"version": "18.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/fs": "^3.1.0",
+				"fs-minipass": "^3.0.0",
+				"glob": "^10.2.2",
+				"lru-cache": "^10.0.1",
+				"minipass": "^7.0.3",
+				"minipass-collect": "^2.0.1",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"p-map": "^4.0.0",
+				"ssri": "^10.0.0",
+				"tar": "^6.1.11",
+				"unique-filename": "^3.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/node-gyp/node_modules/isexe": {
+			"version": "3.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/npm/node_modules/node-gyp/node_modules/make-fetch-happen": {
+			"version": "13.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/agent": "^2.0.0",
+				"cacache": "^18.0.0",
+				"http-cache-semantics": "^4.1.1",
+				"is-lambda": "^1.0.1",
+				"minipass": "^7.0.2",
+				"minipass-fetch": "^3.0.0",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"negotiator": "^0.6.3",
+				"proc-log": "^4.2.0",
+				"promise-retry": "^2.0.1",
+				"ssri": "^10.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/node-gyp/node_modules/minipass-fetch": {
+			"version": "3.0.5",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^7.0.3",
+				"minipass-sized": "^1.0.3",
+				"minizlib": "^2.1.2"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			},
+			"optionalDependencies": {
+				"encoding": "^0.1.13"
+			}
+		},
+		"node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
 			"version": "7.2.1",
 			"dev": true,
 			"inBundle": true,
@@ -6406,43 +6391,127 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
+		"node_modules/npm/node_modules/node-gyp/node_modules/proc-log": {
+			"version": "4.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/node-gyp/node_modules/ssri": {
+			"version": "10.0.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.3"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/node-gyp/node_modules/unique-filename": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"unique-slug": "^4.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/node-gyp/node_modules/unique-slug": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"imurmurhash": "^0.1.4"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/node-gyp/node_modules/which": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^3.1.1"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/nopt": {
+			"version": "8.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"abbrev": "^2.0.0"
+			},
+			"bin": {
+				"nopt": "bin/nopt.js"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/nopt/node_modules/abbrev": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
 		"node_modules/npm/node_modules/normalize-package-data": {
-			"version": "6.0.2",
+			"version": "7.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"hosted-git-info": "^7.0.0",
+				"hosted-git-info": "^8.0.0",
 				"semver": "^7.3.5",
 				"validate-npm-package-license": "^3.0.4"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-audit-report": {
-			"version": "5.0.0",
+			"version": "6.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-bundled": {
-			"version": "3.0.1",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-normalize-package-bin": "^3.0.0"
+				"npm-normalize-package-bin": "^4.0.0"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-install-checks": {
-			"version": "6.3.0",
+			"version": "7.1.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
@@ -6450,99 +6519,112 @@
 				"semver": "^7.1.1"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-normalize-package-bin": {
-			"version": "3.0.1",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-package-arg": {
-			"version": "11.0.3",
+			"version": "12.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"hosted-git-info": "^7.0.0",
-				"proc-log": "^4.0.0",
+				"hosted-git-info": "^8.0.0",
+				"proc-log": "^5.0.0",
 				"semver": "^7.3.5",
-				"validate-npm-package-name": "^5.0.0"
+				"validate-npm-package-name": "^6.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-packlist": {
-			"version": "8.0.2",
+			"version": "9.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"ignore-walk": "^6.0.4"
+				"ignore-walk": "^7.0.0"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/npm-pick-manifest": {
-			"version": "9.1.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"npm-install-checks": "^6.0.0",
-				"npm-normalize-package-bin": "^3.0.0",
-				"npm-package-arg": "^11.0.0",
-				"semver": "^7.3.5"
-			},
-			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/npm-profile": {
 			"version": "10.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"npm-registry-fetch": "^17.0.1",
-				"proc-log": "^4.0.0"
+				"npm-install-checks": "^7.1.0",
+				"npm-normalize-package-bin": "^4.0.0",
+				"npm-package-arg": "^12.0.0",
+				"semver": "^7.3.5"
 			},
 			"engines": {
-				"node": ">=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
-		"node_modules/npm/node_modules/npm-registry-fetch": {
-			"version": "17.1.0",
+		"node_modules/npm/node_modules/npm-profile": {
+			"version": "11.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/redact": "^2.0.0",
-				"jsonparse": "^1.3.1",
-				"make-fetch-happen": "^13.0.0",
-				"minipass": "^7.0.2",
-				"minipass-fetch": "^3.0.0",
-				"minizlib": "^2.1.2",
-				"npm-package-arg": "^11.0.0",
-				"proc-log": "^4.0.0"
+				"npm-registry-fetch": "^18.0.0",
+				"proc-log": "^5.0.0"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-registry-fetch": {
+			"version": "18.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/redact": "^3.0.0",
+				"jsonparse": "^1.3.1",
+				"make-fetch-happen": "^14.0.0",
+				"minipass": "^7.0.2",
+				"minipass-fetch": "^4.0.0",
+				"minizlib": "^3.0.1",
+				"npm-package-arg": "^12.0.0",
+				"proc-log": "^5.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-registry-fetch/node_modules/minizlib": {
+			"version": "3.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^7.0.4",
+				"rimraf": "^5.0.5"
+			},
+			"engines": {
+				"node": ">= 18"
 			}
 		},
 		"node_modules/npm/node_modules/npm-user-validate": {
-			"version": "2.0.1",
+			"version": "3.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/p-map": {
@@ -6567,48 +6649,48 @@
 			"license": "BlueOak-1.0.0"
 		},
 		"node_modules/npm/node_modules/pacote": {
-			"version": "18.0.6",
+			"version": "19.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/git": "^5.0.0",
-				"@npmcli/installed-package-contents": "^2.0.1",
-				"@npmcli/package-json": "^5.1.0",
-				"@npmcli/promise-spawn": "^7.0.0",
-				"@npmcli/run-script": "^8.0.0",
-				"cacache": "^18.0.0",
+				"@npmcli/git": "^6.0.0",
+				"@npmcli/installed-package-contents": "^3.0.0",
+				"@npmcli/package-json": "^6.0.0",
+				"@npmcli/promise-spawn": "^8.0.0",
+				"@npmcli/run-script": "^9.0.0",
+				"cacache": "^19.0.0",
 				"fs-minipass": "^3.0.0",
 				"minipass": "^7.0.2",
-				"npm-package-arg": "^11.0.0",
-				"npm-packlist": "^8.0.0",
-				"npm-pick-manifest": "^9.0.0",
-				"npm-registry-fetch": "^17.0.0",
-				"proc-log": "^4.0.0",
+				"npm-package-arg": "^12.0.0",
+				"npm-packlist": "^9.0.0",
+				"npm-pick-manifest": "^10.0.0",
+				"npm-registry-fetch": "^18.0.0",
+				"proc-log": "^5.0.0",
 				"promise-retry": "^2.0.1",
 				"sigstore": "^2.2.0",
-				"ssri": "^10.0.0",
+				"ssri": "^12.0.0",
 				"tar": "^6.1.11"
 			},
 			"bin": {
 				"pacote": "bin/index.js"
 			},
 			"engines": {
-				"node": "^16.14.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/parse-conflict-json": {
-			"version": "3.0.1",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"json-parse-even-better-errors": "^3.0.0",
+				"json-parse-even-better-errors": "^4.0.0",
 				"just-diff": "^6.0.0",
 				"just-diff-apply": "^5.2.0"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/path-key": {
@@ -6650,21 +6732,21 @@
 			}
 		},
 		"node_modules/npm/node_modules/proc-log": {
-			"version": "4.2.0",
+			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/proggy": {
-			"version": "2.0.0",
+			"version": "3.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/promise-all-reject-late": {
@@ -6705,15 +6787,15 @@
 			}
 		},
 		"node_modules/npm/node_modules/promzard": {
-			"version": "1.0.2",
+			"version": "2.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"read": "^3.0.1"
+				"read": "^4.0.0"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/qrcode-terminal": {
@@ -6725,37 +6807,37 @@
 			}
 		},
 		"node_modules/npm/node_modules/read": {
-			"version": "3.0.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"mute-stream": "^1.0.0"
-			},
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm/node_modules/read-cmd-shim": {
 			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
+			"dependencies": {
+				"mute-stream": "^2.0.0"
+			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/read-cmd-shim": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/read-package-json-fast": {
-			"version": "3.0.2",
+			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"json-parse-even-better-errors": "^3.0.0",
-				"npm-normalize-package-bin": "^3.0.0"
+				"json-parse-even-better-errors": "^4.0.0",
+				"npm-normalize-package-bin": "^4.0.0"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/retry": {
@@ -6765,6 +6847,21 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
+			}
+		},
+		"node_modules/npm/node_modules/rimraf": {
+			"version": "5.0.10",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^10.3.7"
+			},
+			"bin": {
+				"rimraf": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/npm/node_modules/safer-buffer": {
@@ -6923,7 +7020,7 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/npm/node_modules/ssri": {
-			"version": "10.0.6",
+			"version": "12.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -6931,7 +7028,7 @@
 				"minipass": "^7.0.3"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/string-width": {
@@ -7085,7 +7182,119 @@
 				"node": "^16.14.0 || >=18.0.0"
 			}
 		},
-		"node_modules/npm/node_modules/unique-filename": {
+		"node_modules/npm/node_modules/tuf-js/node_modules/@npmcli/agent": {
+			"version": "2.2.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.1",
+				"lru-cache": "^10.0.1",
+				"socks-proxy-agent": "^8.0.3"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/tuf-js/node_modules/@npmcli/fs": {
+			"version": "3.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/tuf-js/node_modules/cacache": {
+			"version": "18.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/fs": "^3.1.0",
+				"fs-minipass": "^3.0.0",
+				"glob": "^10.2.2",
+				"lru-cache": "^10.0.1",
+				"minipass": "^7.0.3",
+				"minipass-collect": "^2.0.1",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"p-map": "^4.0.0",
+				"ssri": "^10.0.0",
+				"tar": "^6.1.11",
+				"unique-filename": "^3.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/tuf-js/node_modules/make-fetch-happen": {
+			"version": "13.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/agent": "^2.0.0",
+				"cacache": "^18.0.0",
+				"http-cache-semantics": "^4.1.1",
+				"is-lambda": "^1.0.1",
+				"minipass": "^7.0.2",
+				"minipass-fetch": "^3.0.0",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"negotiator": "^0.6.3",
+				"proc-log": "^4.2.0",
+				"promise-retry": "^2.0.1",
+				"ssri": "^10.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/tuf-js/node_modules/minipass-fetch": {
+			"version": "3.0.5",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^7.0.3",
+				"minipass-sized": "^1.0.3",
+				"minizlib": "^2.1.2"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			},
+			"optionalDependencies": {
+				"encoding": "^0.1.13"
+			}
+		},
+		"node_modules/npm/node_modules/tuf-js/node_modules/proc-log": {
+			"version": "4.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/tuf-js/node_modules/ssri": {
+			"version": "10.0.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.3"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/tuf-js/node_modules/unique-filename": {
 			"version": "3.0.0",
 			"dev": true,
 			"inBundle": true,
@@ -7097,7 +7306,7 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
-		"node_modules/npm/node_modules/unique-slug": {
+		"node_modules/npm/node_modules/tuf-js/node_modules/unique-slug": {
 			"version": "4.0.0",
 			"dev": true,
 			"inBundle": true,
@@ -7107,6 +7316,30 @@
 			},
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/unique-filename": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"unique-slug": "^5.0.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/unique-slug": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"imurmurhash": "^0.1.4"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/util-deprecate": {
@@ -7136,12 +7369,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/validate-npm-package-name": {
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/walk-up-path": {
@@ -7151,7 +7384,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/which": {
-			"version": "4.0.0",
+			"version": "5.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -7162,7 +7395,7 @@
 				"node-which": "bin/which.js"
 			},
 			"engines": {
-				"node": "^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/which/node_modules/isexe": {
@@ -7275,7 +7508,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/write-file-atomic": {
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -7284,7 +7517,7 @@
 				"signal-exit": "^4.0.1"
 			},
 			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm/node_modules/yallist": {
@@ -7297,6 +7530,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
 			"integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+			"deprecated": "This package is no longer supported.",
 			"dev": true,
 			"dependencies": {
 				"are-we-there-yet": "^2.0.0",
@@ -7339,17 +7573,16 @@
 			}
 		},
 		"node_modules/optionator": {
-			"version": "0.9.3",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
-			"integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
-			"dev": true,
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
 			"dependencies": {
-				"@aashutoshrathi/word-wrap": "^1.2.3",
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
 				"levn": "^0.4.1",
 				"prelude-ls": "^1.2.1",
-				"type-check": "^0.4.0"
+				"type-check": "^0.4.0",
+				"word-wrap": "^1.2.5"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
@@ -7425,6 +7658,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/p-filter/node_modules/indent-string": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/p-filter/node_modules/p-map": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-5.5.0.tgz",
@@ -7453,7 +7698,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-			"dev": true,
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
 			},
@@ -7468,7 +7712,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-			"dev": true,
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
@@ -7480,9 +7723,9 @@
 			}
 		},
 		"node_modules/p-map": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.1.tgz",
-			"integrity": "sha512-2wnaR0XL/FDOj+TgpDuRb2KTjLnu3Fma6b1ZUwGY7LcqenMcvP/YFpjpbPKY6WVGsbuJZRuoUz8iPrt8ORnAFw==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.2.tgz",
+			"integrity": "sha512-z4cYYMMdKHzw4O5UkWJImbZynVIo0lSGTXc7bzB1e/rrDqkgGUNysK/o4bTr+0+xKvvLoTyGqYC4Fgljy9qe1Q==",
 			"dev": true,
 			"engines": {
 				"node": ">=18"
@@ -7529,10 +7772,17 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-			"dev": true,
 			"dependencies": {
 				"callsites": "^3.0.0"
 			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/parent-module/node_modules/callsites": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"engines": {
 				"node": ">=6"
 			}
@@ -7605,7 +7855,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -7623,7 +7872,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -7637,13 +7885,19 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/picocolors": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+			"integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
+			"dev": true
+		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
+			"integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
 			"dev": true,
 			"engines": {
-				"node": ">=8.6"
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
@@ -7776,7 +8030,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.8.0"
 			}
@@ -7797,9 +8050,9 @@
 			}
 		},
 		"node_modules/pretty-ms": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.0.0.tgz",
-			"integrity": "sha512-E9e9HJ9R9NasGOgPaPE8VMeiPKAyWR5jcFpNnwIejslIhWqdqOrb2wShBsncMPUb+BcCd2OPYfh7p2W6oemTng==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.1.0.tgz",
+			"integrity": "sha512-o1piW0n3tgKIKCwk2vpM/vOV13zjJzvP37Ioze54YlTHE06m4tjEbzg9WsKkvTuyYln2DHjo5pY4qrZGI0otpw==",
 			"dev": true,
 			"dependencies": {
 				"parse-ms": "^4.0.0"
@@ -7827,7 +8080,6 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -7836,7 +8088,6 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -8035,9 +8286,9 @@
 			}
 		},
 		"node_modules/read-pkg-up/node_modules/yocto-queue": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-			"integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
+			"integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
 			"dev": true,
 			"engines": {
 				"node": ">=12.20"
@@ -8047,17 +8298,18 @@
 			}
 		},
 		"node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
 			"dev": true,
 			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"node_modules/registry-auth-token": {
@@ -8093,7 +8345,7 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/resolve-cwd/node_modules/resolve-from": {
+		"node_modules/resolve-from": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
 			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
@@ -8102,20 +8354,10 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/resolve-from": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
 			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-			"dev": true,
 			"engines": {
 				"iojs": ">=1.0.0",
 				"node": ">=0.10.0"
@@ -8125,6 +8367,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
 			"dev": true,
 			"dependencies": {
 				"glob": "^7.1.3"
@@ -8140,7 +8383,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
 			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -8160,31 +8402,16 @@
 			}
 		},
 		"node_modules/safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
 		},
 		"node_modules/semantic-release": {
 			"version": "24.1.2",
 			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-24.1.2.tgz",
 			"integrity": "sha512-hvEJ7yI97pzJuLsDZCYzJgmRxF8kiEJvNZhf0oiZQcexw+Ycjy4wbdsn/sVMURgNCu8rwbAXJdBRyIxM4pe32g==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@semantic-release/commit-analyzer": "^13.0.0-beta.1",
 				"@semantic-release/error": "^4.0.0",
@@ -8228,7 +8455,6 @@
 			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.1.tgz",
 			"integrity": "sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">= 18"
 			}
@@ -8238,7 +8464,6 @@
 			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.2.tgz",
 			"integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@octokit/auth-token": "^5.0.0",
 				"@octokit/graphql": "^8.0.0",
@@ -8257,7 +8482,6 @@
 			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
 			"integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@octokit/types": "^13.0.0",
 				"universal-user-agent": "^7.0.2"
@@ -8271,7 +8495,6 @@
 			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.1.1.tgz",
 			"integrity": "sha512-ukiRmuHTi6ebQx/HFRCXKbDlOh/7xEV6QUXaE7MJEKGNAncGI/STSbOkl12qVXZrfZdpXctx5O9X1AIaebiDBg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@octokit/request": "^9.0.0",
 				"@octokit/types": "^13.0.0",
@@ -8281,19 +8504,11 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/semantic-release/node_modules/@octokit/openapi-types": {
-			"version": "22.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-			"integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/semantic-release/node_modules/@octokit/plugin-paginate-rest": {
 			"version": "11.3.5",
 			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.5.tgz",
 			"integrity": "sha512-cgwIRtKrpwhLoBi0CUNuY83DPGRMaWVjqVI/bGKsLJ4PzyWZNaEmhHroI2xlrVXkk6nFv0IsZpOp+ZWSWUS2AQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@octokit/types": "^13.6.0"
 			},
@@ -8309,7 +8524,6 @@
 			"resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-7.1.2.tgz",
 			"integrity": "sha512-XOWnPpH2kJ5VTwozsxGurw+svB2e61aWlmk5EVIYZPwFK5F9h4cyPyj9CIKRyMXMHSwpIsI3mPOdpMmrRhe7UQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@octokit/request-error": "^6.0.0",
 				"@octokit/types": "^13.0.0",
@@ -8323,11 +8537,10 @@
 			}
 		},
 		"node_modules/semantic-release/node_modules/@octokit/plugin-throttling": {
-			"version": "9.3.1",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-9.3.1.tgz",
-			"integrity": "sha512-Qd91H4liUBhwLB2h6jZ99bsxoQdhgPk6TdwnClPyTBSDAdviGPceViEgUwj+pcQDmB/rfAXAXK7MTochpHM3yQ==",
+			"version": "9.3.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-9.3.2.tgz",
+			"integrity": "sha512-FqpvcTpIWFpMMwIeSoypoJXysSAQ3R+ALJhXXSG1HTP3YZOIeLmcNcimKaXxTcws+Sh6yoRl13SJ5r8sXc1Fhw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@octokit/types": "^13.0.0",
 				"bottleneck": "^2.15.3"
@@ -8344,7 +8557,6 @@
 			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.3.tgz",
 			"integrity": "sha512-V+TFhu5fdF3K58rs1pGUJIDH5RZLbZm5BI+MNF+6o/ssFNT4vWlCh/tVpF3NxGtP15HUxTTMUbsG5llAuU2CZA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@octokit/endpoint": "^10.0.0",
 				"@octokit/request-error": "^6.0.1",
@@ -8360,7 +8572,6 @@
 			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.5.tgz",
 			"integrity": "sha512-IlBTfGX8Yn/oFPMwSfvugfncK2EwRLjzbrpifNaMY8o/HTEAFqCA1FZxjD9cWvSKBHgrIhc4CSBIzMxiLsbzFQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@octokit/types": "^13.0.0"
 			},
@@ -8368,22 +8579,11 @@
 				"node": ">= 18"
 			}
 		},
-		"node_modules/semantic-release/node_modules/@octokit/types": {
-			"version": "13.6.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.6.0.tgz",
-			"integrity": "sha512-CrooV/vKCXqwLa+osmHLIMUb87brpgUqlqkPGc6iE2wCkUvTrHiXFMhAKoDDaAAYJrtKtrFTgSQTg5nObBEaew==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/openapi-types": "^22.2.0"
-			}
-		},
 		"node_modules/semantic-release/node_modules/@semantic-release/commit-analyzer": {
 			"version": "13.0.0",
 			"resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-13.0.0.tgz",
 			"integrity": "sha512-KtXWczvTAB1ZFZ6B4O+w8HkfYm/OgQb1dUGNFZtDgQ0csggrmkq8sTxhd+lwGF8kMb59/RnG9o4Tn7M/I8dQ9Q==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"conventional-changelog-angular": "^8.0.0",
 				"conventional-changelog-writer": "^8.0.0",
@@ -8406,7 +8606,6 @@
 			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
 			"integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			}
@@ -8416,7 +8615,6 @@
 			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-11.0.0.tgz",
 			"integrity": "sha512-Uon6G6gJD8U1JNvPm7X0j46yxNRJ8Ui6SgK4Zw5Ktu8RgjEft3BGn+l/RX1TTzhhO3/uUcKuqM+/9/ETFxWS/Q==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@octokit/core": "^6.0.0",
 				"@octokit/plugin-paginate-rest": "^11.0.0",
@@ -8447,7 +8645,6 @@
 			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-12.0.1.tgz",
 			"integrity": "sha512-/6nntGSUGK2aTOI0rHPwY3ZjgY9FkXmEHbW9Kr+62NVOsyqpKKeP0lrCH+tphv+EsNdJNmqqwijTEnVWUMQ2Nw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@semantic-release/error": "^4.0.0",
 				"aggregate-error": "^5.0.0",
@@ -8475,7 +8672,6 @@
 			"resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.0.1.tgz",
 			"integrity": "sha512-K0w+5220TM4HZTthE5dDpIuFrnkN1NfTGPidJFm04ULT1DEZ9WG89VNXN7F0c+6nMEpWgqmPvb7vY7JkB2jyyA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"conventional-changelog-angular": "^8.0.0",
 				"conventional-changelog-writer": "^8.0.0",
@@ -8500,7 +8696,6 @@
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.1.tgz",
 			"integrity": "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=16"
 			},
@@ -8508,25 +8703,11 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/semantic-release/node_modules/agent-base": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-			"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/semantic-release/node_modules/aggregate-error": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
 			"integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"clean-stack": "^5.2.0",
 				"indent-string": "^5.0.0"
@@ -8542,15 +8723,13 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
 			"integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
-			"dev": true,
-			"license": "Apache-2.0"
+			"dev": true
 		},
 		"node_modules/semantic-release/node_modules/clean-stack": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.2.0.tgz",
 			"integrity": "sha512-TyUIUJgdFnCISzG5zu3291TAsE77ddchd0bepon1VVQrKLGKFED4iXFEDQ24mIPdPBbyE16PK3F8MYE1CmcBEQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"escape-string-regexp": "5.0.0"
 			},
@@ -8566,7 +8745,6 @@
 			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.0.0.tgz",
 			"integrity": "sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==",
 			"dev": true,
-			"license": "ISC",
 			"dependencies": {
 				"compare-func": "^2.0.0"
 			},
@@ -8579,7 +8757,6 @@
 			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.0.0.tgz",
 			"integrity": "sha512-TQcoYGRatlAnT2qEWDON/XSfnVG38JzA7E0wcGScu7RElQBkg9WWgZd1peCWFcWDh1xfb2CfsrcvOn1bbSzztA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@types/semver": "^7.5.5",
 				"conventional-commits-filter": "^5.0.0",
@@ -8599,7 +8776,6 @@
 			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
 			"integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			}
@@ -8609,7 +8785,6 @@
 			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.0.0.tgz",
 			"integrity": "sha512-TbsINLp48XeMXR8EvGjTnKGsZqBemisPoyWESlpRyR8lif0lcwzqz+NMtYSj1ooF/WYjSuu7wX0CtdeeMEQAmA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"meow": "^13.0.0"
 			},
@@ -8625,7 +8800,6 @@
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
 			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			},
@@ -8638,7 +8812,6 @@
 			"resolved": "https://registry.npmjs.org/execa/-/execa-9.4.0.tgz",
 			"integrity": "sha512-yKHlle2YGxZE842MERVIplWwNH5VYmqqcPFgtnlU//K8gxuFFXu0pwd/CrfXTumFpeEiufsP7+opT/bPJa1yVw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@sindresorhus/merge-streams": "^4.0.0",
 				"cross-spawn": "^7.0.3",
@@ -8665,7 +8838,6 @@
 			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
 			"integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
@@ -8678,7 +8850,6 @@
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
 			"integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@sec-ant/readable-stream": "^0.4.1",
 				"is-stream": "^4.0.1"
@@ -8695,7 +8866,6 @@
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
 			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=10"
 			},
@@ -8708,7 +8878,6 @@
 			"resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
 			"integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@sindresorhus/merge-streams": "^2.1.0",
 				"fast-glob": "^3.3.2",
@@ -8729,7 +8898,6 @@
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.0.0.tgz",
 			"integrity": "sha512-4nw3vOVR+vHUOT8+U4giwe2tcGv+R3pwwRidUe67DoMBTjhrfr6rZYJVVwdkBE+Um050SG+X9tf0Jo4fOpn01w==",
 			"dev": true,
-			"license": "ISC",
 			"dependencies": {
 				"lru-cache": "^10.0.1"
 			},
@@ -8737,28 +8905,25 @@
 				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
-		"node_modules/semantic-release/node_modules/https-proxy-agent": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-			"integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"agent-base": "^7.0.2",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/semantic-release/node_modules/human-signals": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.0.tgz",
 			"integrity": "sha512-/1/GPCpDUCCYwlERiYjxoczfP0zfvZMU/OWgQPMya9AbAE24vseigFdhAMObpc8Q4lc/kjutPfUddDYyAmejnA==",
 			"dev": true,
-			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/semantic-release/node_modules/indent-string": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/semantic-release/node_modules/is-stream": {
@@ -8766,7 +8931,6 @@
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
 			"integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
@@ -8779,7 +8943,6 @@
 			"resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.1.tgz",
 			"integrity": "sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"lodash.capitalize": "^4.2.1",
 				"lodash.escaperegexp": "^4.1.2",
@@ -8791,19 +8954,11 @@
 				"node": "^18.17 || >=20.6.1"
 			}
 		},
-		"node_modules/semantic-release/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/semantic-release/node_modules/meow": {
 			"version": "13.2.0",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
 			"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
@@ -8819,7 +8974,6 @@
 			"funding": [
 				"https://github.com/sponsors/broofa"
 			],
-			"license": "MIT",
 			"bin": {
 				"mime": "bin/cli.js"
 			},
@@ -8832,7 +8986,6 @@
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
 			"integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"path-key": "^4.0.0",
 				"unicorn-magic": "^0.3.0"
@@ -8849,7 +9002,6 @@
 			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
 			"integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
@@ -8862,7 +9014,6 @@
 			"resolved": "https://registry.npmjs.org/p-filter/-/p-filter-4.1.0.tgz",
 			"integrity": "sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"p-map": "^7.0.1"
 			},
@@ -8878,7 +9029,6 @@
 			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-3.0.0.tgz",
 			"integrity": "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			},
@@ -8891,7 +9041,6 @@
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.1.0.tgz",
 			"integrity": "sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.22.13",
 				"index-to-position": "^0.1.2",
@@ -8909,7 +9058,6 @@
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
 			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			},
@@ -8922,7 +9070,6 @@
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
 			"integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			},
@@ -8935,7 +9082,6 @@
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
 			"integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@types/normalize-package-data": "^2.4.3",
 				"normalize-package-data": "^6.0.0",
@@ -8950,22 +9096,11 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/semantic-release/node_modules/resolve-from": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/semantic-release/node_modules/signal-exit": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
 			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
 			"dev": true,
-			"license": "ISC",
 			"engines": {
 				"node": ">=14"
 			},
@@ -8978,7 +9113,6 @@
 			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
 			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=14.16"
 			},
@@ -8991,7 +9125,6 @@
 			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
 			"integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
@@ -9003,17 +9136,12 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
 			"integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
-			"dev": true,
-			"license": "ISC"
+			"dev": true
 		},
 		"node_modules/semver": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -9085,7 +9213,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-			"dev": true,
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
 			},
@@ -9097,7 +9224,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -9147,21 +9273,6 @@
 			"engines": {
 				"node": ">=4"
 			}
-		},
-		"node_modules/signale/node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/signale/node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
 		},
 		"node_modules/signale/node_modules/escape-string-regexp": {
 			"version": "1.0.5",
@@ -9218,12 +9329,15 @@
 			}
 		},
 		"node_modules/slash": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+			"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
 			"dev": true,
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/slice-ansi": {
@@ -9240,18 +9354,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
-			}
-		},
-		"node_modules/slice-ansi/node_modules/ansi-styles": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/source-map": {
@@ -9296,9 +9398,9 @@
 			}
 		},
 		"node_modules/spdx-license-ids": {
-			"version": "3.0.17",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
-			"integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==",
+			"version": "3.0.20",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.20.tgz",
+			"integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
 			"dev": true
 		},
 		"node_modules/split2": {
@@ -9347,28 +9449,7 @@
 				"readable-stream": "^2.0.2"
 			}
 		},
-		"node_modules/stream-combiner2/node_modules/readable-stream": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-			"dev": true,
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/stream-combiner2/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"node_modules/stream-combiner2/node_modules/string_decoder": {
+		"node_modules/string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
@@ -9377,19 +9458,10 @@
 				"safe-buffer": "~5.1.0"
 			}
 		},
-		"node_modules/string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "~5.2.0"
-			}
-		},
 		"node_modules/string-width": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.1.0.tgz",
-			"integrity": "sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
 			"dev": true,
 			"dependencies": {
 				"emoji-regex": "^10.3.0",
@@ -9403,19 +9475,7 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/string-width/node_modules/ansi-regex": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/string-width/node_modules/strip-ansi": {
+		"node_modules/strip-ansi": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
 			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
@@ -9428,18 +9488,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
-		"node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/strip-bom": {
@@ -9464,7 +9512,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -9503,18 +9550,6 @@
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			}
 		},
-		"node_modules/supertap/node_modules/ansi-regex": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
 		"node_modules/supertap/node_modules/argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -9522,6 +9557,18 @@
 			"dev": true,
 			"dependencies": {
 				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/supertap/node_modules/indent-string": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/supertap/node_modules/js-yaml": {
@@ -9537,26 +9584,10 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
-		"node_modules/supertap/node_modules/strip-ansi": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -9565,9 +9596,9 @@
 			}
 		},
 		"node_modules/supports-hyperlinks": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
-			"integrity": "sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.1.0.tgz",
+			"integrity": "sha512-2rn0BZ+/f7puLOHZm1HOJfwBggfaHXUpPUSSG/SWM4TWp5KCfmNYwnC3hruy2rZlMnmWZ+QAGpZfchu3f3695A==",
 			"dev": true,
 			"dependencies": {
 				"has-flag": "^4.0.0",
@@ -9575,6 +9606,9 @@
 			},
 			"engines": {
 				"node": ">=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/tar": {
@@ -9660,8 +9694,7 @@
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-			"dev": true
+			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
 		},
 		"node_modules/thenify": {
 			"version": "3.3.1",
@@ -9700,36 +9733,6 @@
 				"xtend": "~4.0.1"
 			}
 		},
-		"node_modules/through2/node_modules/readable-stream": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-			"dev": true,
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/through2/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
-		},
-		"node_modules/through2/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
 		"node_modules/time-span": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
@@ -9758,7 +9761,6 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dev": true,
 			"dependencies": {
 				"is-number": "^7.0.0"
 			},
@@ -9788,7 +9790,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
 			"integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=16"
 			},
@@ -9800,7 +9801,6 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
 			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-			"dev": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1"
 			},
@@ -9813,7 +9813,6 @@
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
 			"integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
 			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
 			"engines": {
 				"node": ">=16"
 			},
@@ -9825,7 +9824,6 @@
 			"version": "5.4.5",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
 			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -9835,14 +9833,13 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.0.0-alpha.10",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.0.0-alpha.10.tgz",
-			"integrity": "sha512-iMbN7boDtUmcSDor/J022+H4G018W3r3RSUUr7yoghMTmFuKVIkI89xJHDg82DBGYkA0xOoDNPBr7XfRFbEXKQ==",
-			"dev": true,
+			"version": "8.9.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.9.0.tgz",
+			"integrity": "sha512-AuD/FXGYRQyqyOBCpNLldMlsCGvmDNxptQ3Dp58/NXeB+FqyvTfXmMyba3PYa0Vi9ybnj7G8S/yd/4Cw8y47eA==",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.0.0-alpha.10",
-				"@typescript-eslint/parser": "8.0.0-alpha.10",
-				"@typescript-eslint/utils": "8.0.0-alpha.10"
+				"@typescript-eslint/eslint-plugin": "8.9.0",
+				"@typescript-eslint/parser": "8.9.0",
+				"@typescript-eslint/utils": "8.9.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -9855,105 +9852,12 @@
 				"typescript": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
-			"version": "8.0.0-alpha.10",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.0.0-alpha.10.tgz",
-			"integrity": "sha512-4EerPviLfBKgExHARehJgWrCtX2a7+PXBc0LBPlH93ypSgj0LU1ejMgjrB0gcfd6bJ7LN/UGNAAy3B7/Y785sA==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.0.0-alpha.10",
-				"@typescript-eslint/types": "8.0.0-alpha.10",
-				"@typescript-eslint/typescript-estree": "8.0.0-alpha.10",
-				"@typescript-eslint/visitor-keys": "8.0.0-alpha.10",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/typescript-eslint/node_modules/@typescript-eslint/types": {
-			"version": "8.0.0-alpha.10",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.0.0-alpha.10.tgz",
-			"integrity": "sha512-prbN+b/I4yH6H43WmyenMz8K5e34Hs73BQuWXR4wwij3Cg2xNGLPcpjr2cKWKlH4dZQPTz6R6oBeC+LfaoKi8g==",
-			"dev": true,
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.0.0-alpha.10",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.0.0-alpha.10.tgz",
-			"integrity": "sha512-8wBUIhu6IRa440hv5/0ZEnb5JLp/UsfzIXYKRwICUOMTVj2ss1n+w3m1CtT5ghVWy5Z05qkscsbhlKFmZguU8w==",
-			"dev": true,
-			"dependencies": {
-				"@typescript-eslint/types": "8.0.0-alpha.10",
-				"@typescript-eslint/visitor-keys": "8.0.0-alpha.10",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"minimatch": "^9.0.4",
-				"semver": "^7.6.0",
-				"ts-api-utils": "^1.3.0"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/typescript-eslint/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/typescript-eslint/node_modules/minimatch": {
-			"version": "9.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-			"integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-			"dev": true,
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/uglify-js": {
-			"version": "3.17.4",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-			"integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+			"version": "3.19.3",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+			"integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
 			"dev": true,
 			"optional": true,
 			"bin": {
@@ -10018,7 +9922,6 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"dev": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
@@ -10077,7 +9980,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
 			"dependencies": {
 				"isexe": "^2.0.0"
 			},
@@ -10095,6 +9997,15 @@
 			"dev": true,
 			"dependencies": {
 				"string-width": "^1.0.2 || 2 || 3 || 4"
+			}
+		},
+		"node_modules/wide-align/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/wide-align/node_modules/emoji-regex": {
@@ -10126,6 +10037,26 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/wide-align/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/word-wrap": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -10148,6 +10079,48 @@
 			"funding": {
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
 		},
 		"node_modules/wrap-ansi/node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -10173,6 +10146,18 @@
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
 				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -10260,6 +10245,15 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/yargs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/yargs/node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -10289,11 +10283,22 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/yargs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-			"dev": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -10302,11 +10307,10 @@
 			}
 		},
 		"node_modules/yoctocolors": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.0.2.tgz",
-			"integrity": "sha512-Ct97huExsu7cWeEjmrXlofevF8CvzUglJ4iGUet5B8xn1oumtAZBpHU4GzYuoE6PVqcZ5hghtBrSlhwHuR1Jmw==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
+			"integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==",
 			"dev": true,
-			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},

--- a/package.json
+++ b/package.json
@@ -31,8 +31,11 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"dependencies": {
+		"@eslint/js": "9.12.0",
+		"typescript-eslint": "8.9.0"
+	},
 	"devDependencies": {
-		"@eslint/js": "9.4.0",
 		"@technologiestiftung/semantic-release-config": "1.2.4",
 		"@types/eslint": "9.6.1",
 		"@types/eslint__js": "8.42.3",
@@ -40,7 +43,6 @@
 		"eslint": "9.4.0",
 		"prettier": "3.3.3",
 		"semantic-release": "24.1.2",
-		"typescript": "5.4.5",
-		"typescript-eslint": "8.0.0-alpha.10"
+		"typescript": "5.4.5"
 	}
 }


### PR DESCRIPTION
This is necessary because when using this config in another project, eslint complains that those libraries are not installed